### PR TITLE
Add unified storage API

### DIFF
--- a/apidoc/classes/_near_.contractcontext.md
+++ b/apidoc/classes/_near_.contractcontext.md
@@ -29,7 +29,7 @@ Provides context for contract execution, including information about transaction
 
 getcontractName(): `string`
 
-*Defined in [near.ts:20](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L20)*
+*Defined in [near.ts:20](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L20)*
 
 Account ID of contract.
 
@@ -42,7 +42,7 @@ ___
 
 getsender(): `string`
 
-*Defined in [near.ts:13](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L13)*
+*Defined in [near.ts:13](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L13)*
 
 Account ID of transaction sender.
 
@@ -58,7 +58,7 @@ ___
 
 ▸ **getString**(typeIndex: *[BufferTypeIndex](../modules/_near_.md#buffertypeindex)*, key: *`string`*): `string`
 
-*Defined in [near.ts:27](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L27)*
+*Defined in [near.ts:27](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L27)*
 
 Returns context value with given index and key. Internal usage only for now.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -1,0 +1,118 @@
+[near-runtime-ts](../README.md) > ["near"](../modules/_near_.md) > [ContractPromise](../classes/_near_.contractpromise.md)
+
+# Class: ContractPromise
+
+## Hierarchy
+
+**ContractPromise**
+
+## Index
+
+### Properties
+
+* [id](_near_.contractpromise.md#id)
+
+### Methods
+
+* [returnAsResult](_near_.contractpromise.md#returnasresult)
+* [then](_near_.contractpromise.md#then)
+* [all](_near_.contractpromise.md#all)
+* [create](_near_.contractpromise.md#create)
+* [getResults](_near_.contractpromise.md#getresults)
+
+---
+
+## Properties
+
+<a id="id"></a>
+
+###  id
+
+**● id**: *`i32`*
+
+*Defined in [near.ts:451](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L451)*
+
+___
+
+## Methods
+
+<a id="returnasresult"></a>
+
+###  returnAsResult
+
+▸ **returnAsResult**(): `void`
+
+*Defined in [near.ts:461](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L461)*
+
+**Returns:** `void`
+
+___
+<a id="then"></a>
+
+###  then
+
+▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, mana: *`u32`*): [ContractPromise](_near_.contractpromise.md)
+
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L457)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| methodName | `string` |
+| args | `Uint8Array` |
+| mana | `u32` |
+
+**Returns:** [ContractPromise](_near_.contractpromise.md)
+
+___
+<a id="all"></a>
+
+### `<Static>` all
+
+▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
+
+*Defined in [near.ts:465](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L465)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| promises | [ContractPromise](_near_.contractpromise.md)[] |
+
+**Returns:** [ContractPromise](_near_.contractpromise.md)
+
+___
+<a id="create"></a>
+
+### `<Static>` create
+
+▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, mana: *`u32`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
+
+*Defined in [near.ts:453](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L453)*
+
+**Parameters:**
+
+| Name | Type | Default value |
+| ------ | ------ | ------ |
+| contractName | `string` | - |
+| methodName | `string` | - |
+| args | `Uint8Array` | - |
+| mana | `u32` | - |
+| `Default value` amount | `u64` | 0 |
+
+**Returns:** [ContractPromise](_near_.contractpromise.md)
+
+___
+<a id="getresults"></a>
+
+### `<Static>` getResults
+
+▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
+
+*Defined in [near.ts:473](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L473)*
+
+**Returns:** [ContractPromiseResult](_near_.contractpromiseresult.md)[]
+
+___
+

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -1,0 +1,38 @@
+[near-runtime-ts](../README.md) > ["near"](../modules/_near_.md) > [ContractPromiseResult](../classes/_near_.contractpromiseresult.md)
+
+# Class: ContractPromiseResult
+
+## Hierarchy
+
+**ContractPromiseResult**
+
+## Index
+
+### Properties
+
+* [buffer](_near_.contractpromiseresult.md#buffer)
+* [success](_near_.contractpromiseresult.md#success)
+
+---
+
+## Properties
+
+<a id="buffer"></a>
+
+###  buffer
+
+**● buffer**: *`Uint8Array`*
+
+*Defined in [near.ts:493](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L493)*
+
+___
+<a id="success"></a>
+
+###  success
+
+**● success**: *`bool`*
+
+*Defined in [near.ts:492](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L492)*
+
+___
+

--- a/apidoc/classes/_near_.globalstorage.md
+++ b/apidoc/classes/_near_.globalstorage.md
@@ -14,12 +14,16 @@ For now it's just simple key-value store with prefix queries.
 
 ### Methods
 
+* [get](_near_.globalstorage.md#get)
+* [getArray](_near_.globalstorage.md#getarray)
 * [getBytes](_near_.globalstorage.md#getbytes)
 * [getItem](_near_.globalstorage.md#getitem)
 * [getString](_near_.globalstorage.md#getstring)
 * [getU64](_near_.globalstorage.md#getu64)
 * [keys](_near_.globalstorage.md#keys)
 * [removeItem](_near_.globalstorage.md#removeitem)
+* [set](_near_.globalstorage.md#set)
+* [setArray](_near_.globalstorage.md#setarray)
 * [setBytes](_near_.globalstorage.md#setbytes)
 * [setItem](_near_.globalstorage.md#setitem)
 * [setString](_near_.globalstorage.md#setstring)
@@ -29,13 +33,59 @@ For now it's just simple key-value store with prefix queries.
 
 ## Methods
 
+<a id="get"></a>
+
+###  get
+
+▸ **get**<`T`>(key: *`string`*): `T`
+
+*Defined in [near.ts:183](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L183)*
+
+Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bools, integers, floats, string and typed arrays. For common/dynamic arrays use {@link #getArray}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| key | `string` |  A key to read from storage. |
+
+**Returns:** `T`
+A value of type T stored under the given key.
+
+___
+<a id="getarray"></a>
+
+###  getArray
+
+▸ **getArray**<`T`>(key: *`string`*): `T`[]
+
+*Defined in [near.ts:199](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L199)*
+
+Gets given array of a generic type stored under the key. Key is encoded as UTF-8 strings. Supported types: arrays of bools, integers and floats. For typed arrays use {@link #get}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| key | `string` |  A key to read from storage. |
+
+**Returns:** `T`[]
+An array of type T stored under the given key.
+
+___
 <a id="getbytes"></a>
 
 ###  getBytes
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:112](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L112)*
+*Defined in [near.ts:112](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L112)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -56,7 +106,7 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:70](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L70)*
+*Defined in [near.ts:70](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L70)*
 
 **Parameters:**
 
@@ -73,7 +123,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:84](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L84)*
+*Defined in [near.ts:84](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L84)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -92,7 +142,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:141](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L141)*
+*Defined in [near.ts:141](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L141)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -112,7 +162,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*): `string`[]
 
-*Defined in [near.ts:52](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L52)*
+*Defined in [near.ts:52](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L52)*
 
 Returns list of keys starting with given prefix.
 
@@ -133,7 +183,7 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:123](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L123)*
+*Defined in [near.ts:123](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L123)*
 
 **Parameters:**
 
@@ -144,13 +194,59 @@ ___
 **Returns:** `void`
 
 ___
+<a id="set"></a>
+
+###  set
+
+▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
+
+*Defined in [near.ts:154](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L154)*
+
+Stores given generic value under the key. Key is encoded as UTF-8 strings. Unless the value is a string type, it's encoded as bytes. Supported types: bools, integers, floats, string and typed arrays. For common/dynamic arrays use {@link #setArray}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| key | `string` |  A key to use for storage. |
+| value | `T` |  A value to store. |
+
+**Returns:** `void`
+
+___
+<a id="setarray"></a>
+
+###  setArray
+
+▸ **setArray**<`T`>(key: *`string`*, value: *`T`[]*): `void`
+
+*Defined in [near.ts:171](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L171)*
+
+Stores given generic value under the key. Key is encoded as UTF-8 strings. Unless the value is a string type, it's encoded as bytes. Supported types: arrays of bools, integers and floats. For typed arrays use {@link #set}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| key | `string` |  A key to use for storage. |
+| value | `T`[] |  An array to store. |
+
+**Returns:** `void`
+
+___
 <a id="setbytes"></a>
 
 ###  setBytes
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:102](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L102)*
+*Defined in [near.ts:102](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L102)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -172,7 +268,7 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:67](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L67)*
+*Defined in [near.ts:67](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L67)*
 
 **Parameters:**
 
@@ -190,7 +286,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:77](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L77)*
+*Defined in [near.ts:77](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L77)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -210,7 +306,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:131](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L131)*
+*Defined in [near.ts:131](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L131)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -11,6 +11,8 @@
 ### Classes
 
 * [ContractContext](../classes/_near_.contractcontext.md)
+* [ContractPromise](../classes/_near_.contractpromise.md)
+* [ContractPromiseResult](../classes/_near_.contractpromiseresult.md)
 * [GlobalStorage](../classes/_near_.globalstorage.md)
 
 ### Type aliases
@@ -28,8 +30,16 @@
 
 * [input_read_into](_near_.md#input_read_into)
 * [input_read_len](_near_.md#input_read_len)
+* [promise_and](_near_.md#promise_and)
+* [promise_create](_near_.md#promise_create)
+* [promise_then](_near_.md#promise_then)
 * [read_into](_near_.md#read_into)
 * [read_len](_near_.md#read_len)
+* [result_count](_near_.md#result_count)
+* [result_is_ok](_near_.md#result_is_ok)
+* [result_read_into](_near_.md#result_read_into)
+* [result_read_len](_near_.md#result_read_len)
+* [return_promise](_near_.md#return_promise)
 * [return_value](_near_.md#return_value)
 * [storage_iter](_near_.md#storage_iter)
 * [storage_iter_next](_near_.md#storage_iter_next)
@@ -37,6 +47,7 @@
 * [storage_iter_peek_len](_near_.md#storage_iter_peek_len)
 * [storage_read_into](_near_.md#storage_read_into)
 * [storage_read_len](_near_.md#storage_read_len)
+* [storage_remove](_near_.md#storage_remove)
 * [storage_write](_near_.md#storage_write)
 
 ---
@@ -49,7 +60,7 @@
 
 **Ƭ BufferTypeIndex**: *`u32`*
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L1)*
 
 ___
 
@@ -61,7 +72,7 @@ ___
 
 **● BUFFER_TYPE_CURRENT_ACCOUNT_ID**: *[BufferTypeIndex](_near_.md#buffertypeindex)* = 2
 
-*Defined in [near.ts:4](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L4)*
+*Defined in [near.ts:4](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L4)*
 
 ___
 <a id="buffer_type_originator_account_id"></a>
@@ -70,7 +81,7 @@ ___
 
 **● BUFFER_TYPE_ORIGINATOR_ACCOUNT_ID**: *[BufferTypeIndex](_near_.md#buffertypeindex)* = 1
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L3)*
 
 ___
 <a id="contractcontext-1"></a>
@@ -79,7 +90,7 @@ ___
 
 **● contractContext**: *[ContractContext](../classes/_near_.contractcontext.md)* =  new ContractContext()
 
-*Defined in [near.ts:147](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L147)*
+*Defined in [near.ts:205](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L205)*
 
 ___
 <a id="globalstorage-1"></a>
@@ -88,7 +99,7 @@ ___
 
 **● globalStorage**: *[GlobalStorage](../classes/_near_.globalstorage.md)* =  new GlobalStorage()
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L146)*
+*Defined in [near.ts:204](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L204)*
 
 ___
 
@@ -100,7 +111,7 @@ ___
 
 ▸ **input_read_into**(ptr: *`usize`*): `void`
 
-*Defined in [near.ts:299](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L299)*
+*Defined in [near.ts:518](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L518)*
 
 **Parameters:**
 
@@ -117,9 +128,68 @@ ___
 
 ▸ **input_read_len**(): `usize`
 
-*Defined in [near.ts:297](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L297)*
+*Defined in [near.ts:516](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L516)*
 
 **Returns:** `usize`
+
+___
+<a id="promise_and"></a>
+
+###  promise_and
+
+▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
+
+*Defined in [near.ts:546](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L546)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| promise_index1 | `u32` |
+| promise_index2 | `u32` |
+
+**Returns:** `u32`
+
+___
+<a id="promise_create"></a>
+
+###  promise_create
+
+▸ **promise_create**(account_id: *`usize`*, method_name: *`usize`*, args: *`usize`*, mana: *`u32`*, amount: *`u64`*): `u32`
+
+*Defined in [near.ts:540](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L540)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| account_id | `usize` |
+| method_name | `usize` |
+| args | `usize` |
+| mana | `u32` |
+| amount | `u64` |
+
+**Returns:** `u32`
+
+___
+<a id="promise_then"></a>
+
+###  promise_then
+
+▸ **promise_then**(promise_index: *`u32`*, method_name: *`usize`*, args: *`usize`*, mana: *`u32`*): `u32`
+
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L543)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| promise_index | `u32` |
+| method_name | `usize` |
+| args | `usize` |
+| mana | `u32` |
+
+**Returns:** `u32`
 
 ___
 <a id="read_into"></a>
@@ -128,7 +198,7 @@ ___
 
 ▸ **read_into**(type_index: *`u32`*, key: *`usize`*, value: *`usize`*): `void`
 
-*Defined in [near.ts:307](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L307)*
+*Defined in [near.ts:537](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L537)*
 
 **Parameters:**
 
@@ -147,7 +217,7 @@ ___
 
 ▸ **read_len**(type_index: *`u32`*, key: *`usize`*): `u32`
 
-*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L305)*
+*Defined in [near.ts:535](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L535)*
 
 **Parameters:**
 
@@ -159,13 +229,93 @@ ___
 **Returns:** `u32`
 
 ___
+<a id="result_count"></a>
+
+###  result_count
+
+▸ **result_count**(): `u32`
+
+*Defined in [near.ts:521](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L521)*
+
+**Returns:** `u32`
+
+___
+<a id="result_is_ok"></a>
+
+###  result_is_ok
+
+▸ **result_is_ok**(index: *`u32`*): `bool`
+
+*Defined in [near.ts:523](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L523)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| index | `u32` |
+
+**Returns:** `bool`
+
+___
+<a id="result_read_into"></a>
+
+###  result_read_into
+
+▸ **result_read_into**(index: *`u32`*, value: *`usize`*): `void`
+
+*Defined in [near.ts:527](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L527)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| index | `u32` |
+| value | `usize` |
+
+**Returns:** `void`
+
+___
+<a id="result_read_len"></a>
+
+###  result_read_len
+
+▸ **result_read_len**(index: *`u32`*): `u32`
+
+*Defined in [near.ts:525](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L525)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| index | `u32` |
+
+**Returns:** `u32`
+
+___
+<a id="return_promise"></a>
+
+###  return_promise
+
+▸ **return_promise**(promise_index: *`u32`*): `void`
+
+*Defined in [near.ts:532](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L532)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| promise_index | `u32` |
+
+**Returns:** `void`
+
+___
 <a id="return_value"></a>
 
 ###  return_value
 
 ▸ **return_value**(value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:302](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L302)*
+*Defined in [near.ts:530](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L530)*
 
 **Parameters:**
 
@@ -182,7 +332,7 @@ ___
 
 ▸ **storage_iter**(prefix: *`usize`*): `u32`
 
-*Defined in [near.ts:288](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L288)*
+*Defined in [near.ts:507](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L507)*
 
 **Parameters:**
 
@@ -199,7 +349,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:290](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L290)*
+*Defined in [near.ts:509](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L509)*
 
 **Parameters:**
 
@@ -216,7 +366,7 @@ ___
 
 ▸ **storage_iter_peek_into**(id: *`u32`*, value: *`usize`*): `void`
 
-*Defined in [near.ts:294](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L294)*
+*Defined in [near.ts:513](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L513)*
 
 **Parameters:**
 
@@ -234,7 +384,7 @@ ___
 
 ▸ **storage_iter_peek_len**(id: *`u32`*): `usize`
 
-*Defined in [near.ts:292](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L292)*
+*Defined in [near.ts:511](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L511)*
 
 **Parameters:**
 
@@ -251,7 +401,7 @@ ___
 
 ▸ **storage_read_into**(key: *`usize`*, value: *`usize`*): `void`
 
-*Defined in [near.ts:286](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L286)*
+*Defined in [near.ts:503](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L503)*
 
 **Parameters:**
 
@@ -269,7 +419,7 @@ ___
 
 ▸ **storage_read_len**(key: *`usize`*): `usize`
 
-*Defined in [near.ts:284](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L284)*
+*Defined in [near.ts:501](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L501)*
 
 **Parameters:**
 
@@ -280,13 +430,30 @@ ___
 **Returns:** `usize`
 
 ___
+<a id="storage_remove"></a>
+
+###  storage_remove
+
+▸ **storage_remove**(key: *`usize`*): `void`
+
+*Defined in [near.ts:505](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L505)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| key | `usize` |
+
+**Returns:** `void`
+
+___
 <a id="storage_write"></a>
 
 ###  storage_write
 
 ▸ **storage_write**(key: *`usize`*, value: *`usize`*): `void`
 
-*Defined in [near.ts:282](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L282)*
+*Defined in [near.ts:499](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L499)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -9,12 +9,17 @@
 * [base58](_near_.near.md#base58)
 * [bufferWithSize](_near_.near.md#bufferwithsize)
 * [bufferWithSizeFromPtr](_near_.near.md#bufferwithsizefromptr)
+* [decode](_near_.near.md#decode)
+* [decodeArray](_near_.near.md#decodearray)
+* [encode](_near_.near.md#encode)
+* [encodeArray](_near_.near.md#encodearray)
 * [hash](_near_.near.md#hash)
 * [hash32](_near_.near.md#hash32)
 * [log](_near_.near.md#log)
 * [random32](_near_.near.md#random32)
 * [randomBuffer](_near_.near.md#randombuffer)
 * [str](_near_.near.md#str)
+* [stringFromBytes](_near_.near.md#stringfrombytes)
 * [utf8](_near_.near.md#utf8)
 
 ---
@@ -27,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:225](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L225)*
+*Defined in [near.ts:396](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L396)*
 
 **Parameters:**
 
@@ -44,7 +49,7 @@ ___
 
 ▸ **bufferWithSize**(buf: *`Uint8Array`*): `Uint8Array`
 
-*Defined in [near.ts:208](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L208)*
+*Defined in [near.ts:379](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L379)*
 
 **Parameters:**
 
@@ -61,7 +66,7 @@ ___
 
 ▸ **bufferWithSizeFromPtr**(ptr: *`usize`*, length: *`usize`*): `Uint8Array`
 
-*Defined in [near.ts:198](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L198)*
+*Defined in [near.ts:369](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L369)*
 
 **Parameters:**
 
@@ -73,13 +78,105 @@ ___
 **Returns:** `Uint8Array`
 
 ___
+<a id="decode"></a>
+
+###  decode
+
+▸ **decode**<`T`>(buf: *`Uint8Array`*): `T`
+
+*Defined in [near.ts:297](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L297)*
+
+Decodes given value from the array of bytes. Supported types: bool, integers, floats and typed arrays. For common/dynamic arrays use {@link #decodeArray}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| buf | `Uint8Array` |  Uin8Array of bytes to decode. |
+
+**Returns:** `T`
+A decoded value.
+
+___
+<a id="decodearray"></a>
+
+###  decodeArray
+
+▸ **decodeArray**<`T`>(buf: *`Uint8Array`*): `T`[]
+
+*Defined in [near.ts:248](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L248)*
+
+Decodes an array of type T from the given Uint8Array of bytes. Supported types: arrays of bools, integers and floats. For typed arrays use {@link #decode}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| buf | `Uint8Array` |  Uin8Array of bytes to decode. |
+
+**Returns:** `T`[]
+A decoded array of type T.
+
+___
+<a id="encode"></a>
+
+###  encode
+
+▸ **encode**<`T`>(value: *`T`*): `Uint8Array`
+
+*Defined in [near.ts:268](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L268)*
+
+Encodes given value to an array of bytes. Supported types: bool, integers, floats and typed arrays. For common/dynamic arrays use {@link #encodeArray}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| value | `T` |  A value to encode. |
+
+**Returns:** `Uint8Array`
+An encoded value.
+
+___
+<a id="encodearray"></a>
+
+###  encodeArray
+
+▸ **encodeArray**<`T`>(value: *`T`[]*): `Uint8Array`
+
+*Defined in [near.ts:229](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L229)*
+
+Encodes a given array of type T into Uint8Array of bytes. Supported types: arrays of bools, integers and floats. For typed arrays use {@link #encode}
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| value | `T`[] |  An array to encode |
+
+**Returns:** `Uint8Array`
+An encoded array.
+
+___
 <a id="hash"></a>
 
 ###  hash
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:154](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L154)*
+*Defined in [near.ts:325](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L325)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -101,7 +198,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:171](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L171)*
+*Defined in [near.ts:342](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L342)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -123,7 +220,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:212](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L212)*
+*Defined in [near.ts:383](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L383)*
 
 **Parameters:**
 
@@ -140,7 +237,7 @@ ___
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:194](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L194)*
+*Defined in [near.ts:365](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L365)*
 
 Returns random 32-bit integer.
 
@@ -153,7 +250,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L185)*
+*Defined in [near.ts:356](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L356)*
 
 Returns random byte buffer of given length.
 
@@ -172,7 +269,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:216](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L216)*
+*Defined in [near.ts:387](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L387)*
 
 **Type parameters:**
 
@@ -186,13 +283,37 @@ ___
 **Returns:** `string`
 
 ___
+<a id="stringfrombytes"></a>
+
+###  stringFromBytes
+
+▸ **stringFromBytes**(buf: *`Uint8Array`*): `string`
+
+*Defined in [near.ts:217](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L217)*
+
+Converts A UTF-8 encoded Uint8Array of bytes to a string. It's helpful to debug encoded messages. E.g.
+
+```
+near.log(near.stringFromBytes(fooBarModel.encode()));
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| buf | `Uint8Array` |  A UTF-8 encoded Uint8 array of bytes to convert. |
+
+**Returns:** `string`
+Decoded string.
+
+___
 <a id="utf8"></a>
 
 ###  utf8
 
 ▸ **utf8**(value: *`string`*): `usize`
 
-*Defined in [near.ts:221](https://github.com/nearprotocol/near-runtime-ts/blob/a6cbaa1/near.ts#L221)*
+*Defined in [near.ts:392](https://github.com/nearprotocol/near-runtime-ts/blob/3c38d38/near.ts#L392)*
 
 **Parameters:**
 

--- a/near.ts
+++ b/near.ts
@@ -226,7 +226,7 @@ export namespace near {
    * @param value An array to encode
    * @returns An encoded array.
    */
-  function encodeArray<T>(value: T[]): Uint8Array {
+  export function encodeArray<T>(value: T[]): Uint8Array {
     if (isInteger<T>() || isFloat<T>()) {
       let tmp = new Uint8Array(4 + value.buffer_.byteLength);
       store<i32>(tmp.buffer.data, value.length);
@@ -245,7 +245,7 @@ export namespace near {
    * @param buf Uin8Array of bytes to decode.
    * @returns A decoded array of type T.
    */
-  function decodeArray<T>(buf: Uint8Array): T[] {
+  export function decodeArray<T>(buf: Uint8Array): T[] {
     if (isInteger<T>() || isFloat<T>()) {
       let value = new Array<T>();
       value.length_ = load<i32>(buf.buffer.data, 0);


### PR DESCRIPTION
Most of the tests are here: https://studio.nearprotocol.com/?f=5vobbkbiq

Would be nice to add support for decode/encode for generated objects from `model.ts`. To do this we would need to support non-static .decode. So I can do:
`return instantiate<T>.decode(buf)`

I run `npm run doc`, which generated docs that I linked to this commit.