### PR TITLE
Adding new set/get API and collections

### DIFF
--- a/near.ts
+++ b/near.ts
@@ -33,10 +33,16 @@ export class Storage {
     return result;
   }
 
+  /**
+   * @deprecated Use setString or set<string>
+   */
   setItem(key: string, value: string): void {
     this.setString(key, value);
   }
 
+  /**
+   * @deprecated Use getString or get<string>
+   */
   getItem(key: string): string {
     return this.getString(key);
   }
@@ -79,8 +85,15 @@ export class Storage {
     return storage_has_key(key.lengthUTF8 - 1, key.toUTF8());
   }
 
-  removeItem(key: string): void {
+  remove(key: string): void {
     storage_remove(key.lengthUTF8 - 1, key.toUTF8());
+  }
+
+  /**
+   * @deprecated User #remove
+   */
+  removeItem(key: string): void {
+    this.remove(key);
   }
 
   /**
@@ -99,6 +112,56 @@ export class Storage {
    */
   getU64(key: string): u64 {
     return U64.parseInt(this.getItem(key) || "0");
+  }
+
+  /**
+   * Stores given generic value under the key. Key is encoded as UTF-8 strings.
+   * Supported types: bools, integers, string and data objects defined in model.ts.
+   *
+   * @param key A key to use for storage.
+   * @param value A value to store.
+   */
+  set<T>(key: string, value: T): void {
+    if (isString<T>()) {
+      this.setString(key, value);
+    } else if (isInteger<T>()) {
+      this.setString(key, value.toString());
+    } else {
+      this.setBytes(key, value.encode());
+    }
+  }
+
+  /**
+   * Gets given generic value stored under the key. Key is encoded as UTF-8 strings.
+   * Supported types: bools, integers, string and data objects defined in model.ts.
+   * For common/dynamic arrays use {@link #getArray}
+   *
+   * @param key A key to read from storage.
+   * @param defaultValue The default value if the key is not available
+   * @returns A value of type T stored under the given key.
+   */
+  get<T>(key: string, defaultValue: T = null): T {
+    if (isString<T>()) { 
+      return this.getString(key) || defaultValue;
+    } else if (isInteger<T>()) {
+      let s = this.getString(key);
+      if (s != null) {
+        if (isSigned<T>()) {
+          return <T>I64.parseInt(s);
+        } else {
+          return <T>U64.parseInt(s);
+        }
+      } else {
+        return defaultValue;
+      }
+    } else {
+      let bytes = this.getBytes(key);
+      if (bytes != null) {
+        return instantiate<T>().decode(bytes);
+      } else {
+        return defaultValue;
+      }
+    }
   }
 
   /**
@@ -150,7 +213,495 @@ export class Storage {
   }
 }
 
+/**
+ * An instance of a Storage class that is used for working with contract storage on the blockchain.
+ */
 export let storage: Storage = new Storage();
+
+/**
+ * A namespace with classes and functions for persistent collections on the blockchain. 
+ */
+export namespace collections {
+  const _KEY_LENGTH_SUFFIX = ":len";
+  const _KEY_FRONT_INDEX_SUFFIX = ":front";
+  const _KEY_BACK_INDEX_SUFFIX = ":back";
+  const _KEY_ELEMENT_SUFFIX = "::";
+
+  /**
+   * A vector class that implements a persistent array.
+   */
+  export class Vector<T> {
+    private _elementPrefix: string;
+    private _lengthKey: string;
+    private _length: i32;
+
+    /**
+     * Creates or restores a persistent vector with a given storage prefix.
+     * Always use a unique storage prefix for different collections.
+     * @param prefix A prefix to use for every key of this vector.
+     */
+    constructor(prefix: string) {
+      this._elementPrefix = prefix + _KEY_ELEMENT_SUFFIX;
+      this._lengthKey = prefix + _KEY_LENGTH_SUFFIX;
+      this._length = -1;
+    }
+
+    /**
+     * @returns An interal key for a given index.
+     */
+    @inline
+    private _key(index: i32): string {
+      return this._elementPrefix + index.toString();
+    }
+
+    /**
+     * Removes the content of the element from storage without changing length of the vector.
+     * @param index The index of the element to remove.
+     */
+    remove(index: i32): void {
+      assert(this.containsIndex(index), "Index out of range");
+      return storage.remove(this._key(index));
+    }
+
+    /**
+     * @param index The index to check.
+     * @returns True if the given index is within the range of the vector indices.
+     */
+    containsIndex(index: i32): bool {
+      return index >= 0 && index < this.length;
+    }
+
+    /**
+     * @returns True if the vector is empty.
+     */
+    get isEmpty(): bool {
+      return this.length == 0;
+    }
+
+    /**
+     * @returns The length of the vector.
+     */
+    get length(): i32 {
+      if (this._length < 0) {
+        this._length = storage.get<i32>(this._lengthKey, 0);
+      }
+      return this._length;
+    }
+
+    /**
+     * Internally sets the length of the vector
+     */
+    private set length(value: i32) {
+      this._length = value;
+      storage.set<i32>(this._lengthKey, value);
+    }
+
+    /**
+     * Returns the element of the vector for a given index. Asserts the given index is within the
+     * range of the vector.
+     * @param index The index of the element to return.
+     * @returns The element at the given index.
+     */
+    @operator("[]")
+    private __get(index: i32): T {
+      assert(this.containsIndex(index), "Index out of range");
+      return this.__unchecked_get(index);
+    }
+
+    /**
+     * Returns the element of the vector for a given index without checks.
+     * @param index The index of the element to return.
+     * @returns The element at the given index.
+     */
+    @operator("{}")
+    private __unchecked_get(index: i32): T {
+      return storage.get<T>(this._key(index));
+    }
+
+    /**
+     * Sets the value of an element at the given index. Asserts the given index is within the
+     * range of the vector.
+     * @param index The index of the element.
+     * @param value The new value.
+     */
+    @operator("[]=")
+    private __set(index: i32, value: T): void {
+      assert(index >= 0 && index < this.length, "Index out of range");
+      this.__unchecked_set(index, value);
+    }
+
+    /**
+     * Sets the value of an element at the given index without checks.
+     * @param index The index of the element.
+     * @param value The new value.
+     */
+    @operator("{}=")
+    private __unchecked_set(index: i32, value: T): void {
+      storage.set<T>(this._key(index), value);
+    }
+
+    /**
+     * Adds a new element to the end of the vector. Increases the length of the vector.
+     * @param element A new element to add.
+     * @returns The index of a newly added element
+     */
+    push(element: T): i32 {
+      let index = this.length;
+      this.length = index + 1;
+      this.__unchecked_set(index, element);
+      return index;
+    }
+
+    /**
+     * Adds a new element to the end of the vector. Increases the length of the vector.
+     * @param element A new element to add.
+     * @returns The index of a newly added element
+     */
+    @inline
+    pushBack(element: T): i32 {
+      return this.push(element);
+    }
+
+    /**
+     * Removes the last element from the vector and returns it. Asserts that the vector is not empty.
+     * Decreases the length of the vector.
+     * @returns The removed last element of the vector.
+     */
+    pop(): T {
+      assert(this.length > 0, "Vector is empty");
+      let index = this.length - 1;
+      this.length = index;
+      let result = this.__unchecked_get(index);
+      storage.remove(this._key(index));
+      return result;
+    }
+
+    /**
+     * Removes the last element from the vector and returns it. Asserts that the vector is not empty.
+     * Decreases the length of the vector.
+     * @returns The removed last element of the vector.
+     */
+    @inline
+    popBack(): T {
+      return this.pop();
+    }
+
+    /**
+     * @returns The last element of the vector. Asserts that the vector is not empty.
+     */
+    get back(): T {
+      return this.__get(this.length - 1);
+    }
+
+    /**
+     * @returns The first element of the vector. Asserts that the vector is not empty.
+     */
+    get front(): T {
+      return this.__get(0);
+    }
+  }
+
+
+  /**
+   * A deque class that implements a persistent bidirectional queue.
+   */
+  export class Deque<T> {
+    private _elementPrefix: string;
+    private _frontIndexKey: string;
+    private _backIndexKey: string;
+    private _frontIndex: i32;
+    private _backIndex: i32;
+
+    /**
+     * Creates or restores a persistent deque with a given storage prefix.
+     * Always use a unique storage prefix for different collections.
+     * @param prefix A prefix to use for every key of this deque.
+     */
+    constructor(prefix: string) {
+      this._elementPrefix = prefix + _KEY_ELEMENT_SUFFIX;
+      this._frontIndexKey = prefix + _KEY_FRONT_INDEX_SUFFIX;
+      this._backIndexKey = prefix + _KEY_BACK_INDEX_SUFFIX;
+      this._frontIndex = i32.MIN_VALUE;
+      this._backIndex = i32.MAX_VALUE;
+    }
+
+    /**
+     * @returns An interal key for a given index.
+     */
+    @inline
+    private _key(index: i32): string {
+      return this._elementPrefix + index.toString();
+    }
+
+    /**
+     * @returns The index of the first/front element of the deque (inclusive).
+     */
+    private get frontIndex(): i32 {
+      if (this._frontIndex == i32.MIN_VALUE) {
+        this._frontIndex = storage.get<i32>(this._frontIndexKey, 0);
+      }
+      return this._frontIndex;
+    }
+
+    /**
+     * Internal. Sets the index of the first/front element.
+     */
+    private set frontIndex(value: i32) {
+      this._frontIndex = value;
+      storage.set<i32>(this._frontIndexKey, value);
+    }
+
+    /**
+     * @returns The index of the last/back element of the deque (inclusive).
+     */
+    private get backIndex(): i32 {
+      if (this._backIndex == i32.MAX_VALUE) {
+        this._backIndex = storage.get<i32>(this._backIndex, -1);
+      }
+      return this._backIndex;
+    }
+
+    /**
+     * Internal. Sets the index of the last/back element.
+     */
+    private set backIndex(value: i32) {
+      this._backIndex = value;
+      storage.set<i32>(this._backIndex, value);
+    }
+
+    /**
+     * @param index The index to check.
+     * @returns True if the given index is within the range of the deque indices.
+     */
+    containsIndex(index: i32): bool {
+      return index >= 0 && index < this.length;
+    }
+
+    /**
+     * Removes the content of the element from storage without changing length of the deque.
+     * @param index The index of the element to remove.
+     */
+    remove(index: i32): void {
+      index -= this.frontIndex;
+      assert(this.containsIndex(index), "Index out of range");
+      return storage.remove(this._key(index));
+    }
+
+    /**
+     * @returns The length of the deque.
+     */
+    get length() {
+      return this.backIndex - this.frontIndex + 1;
+    }
+
+    /**
+     * @returns True if the deque is empty.
+     */
+    get isEmpty(): bool {
+      return this.length == 0;
+    }
+
+    /**
+     * Returns the element of the deque for a given index. Asserts the given index is within the
+     * range of the vector.
+     * @param index The index of the element to return.
+     * @returns The element at the given index.
+     */
+    @operator("[]")
+    private __get(index: i32): T {
+      assert(this.containsIndex(index - this.frontIndex), "Index out of range");
+      return this.__unchecked_get(index);
+    }
+
+    /**
+     * Returns the element of the deque for a given index without checks.
+     * @param index The index of the element to return.
+     * @returns The element at the given index.
+     */
+    @operator("{}")
+    private __unchecked_get(index: i32): T {
+      return storage.get<T>(this._key(index - this.frontIndex));
+    }
+
+    /**
+     * Sets the new value of an element at the given index. Asserts the given index is within the
+     * range of the deque.
+     * @param index The index of the element.
+     * @param value The new value.
+     */
+    @operator("[]=")
+    private __set(index: i32, value: T): void {
+      assert(this.containsIndex(index - this.frontIndex), "Index out of range");
+      this.__unchecked_set(index, value);
+    }
+
+    /**
+     * Sets the new value of an element at the given index without checks.
+     * @param index The index of the element.
+     * @param value The new value.
+     */
+    @operator("{}=")
+    private __unchecked_set(index: i32, value: T): void {
+      storage.set<T>(this._key(index - this.frontIndex), value);
+    }
+
+    /**
+     * Adds a new element in front of the deque. Increases the length of the deque.
+     * @param element A new element to add.
+     * @returns The index of a newly added element
+     */
+    pushFront(element: T): i32 {
+      this.frontIndex -= 1;
+      this.__unchecked_set(0, element);
+      return 0;
+    }
+
+    /**
+     * Removes the first/front element from the deque and returns it.
+     * Asserts that the deque is not empty. Decreases the length of the deque.
+     * @returns The removed first element of the queue.
+     */
+    popFront(): T {
+      assert(this.length > 0, "Deque is empty");
+      let result = this.__unchecked_get(0);
+      storage.remove(this._key(this.frontIndex));
+      this.frontIndex += 1;
+      return result;
+    }
+
+    /**
+     * @returns The first/front element of the deque.
+     */
+    get front(): T {
+      return this.__get(0);
+    }
+
+    /**
+     * Adds a new element to the end of the deque. Increases the length of the deque.
+     * @param element A new element to add.
+     * @returns The index of a newly added element
+     */
+    pushBack(element: T): i32 {
+      let index = this.length;
+      this.backIndex += 1;
+      this.__unchecked_set(index, element);
+      return index;
+    }
+
+    /**
+     * Removes the last/back element from the deque and returns it.
+     * Asserts that the deque is not empty. Decreases the length of the deque.
+     * @returns The removed first element of the queue.
+     */
+    popBack(): T {
+      let index = this.length;
+      assert(index > 0, "Deque is empty");
+      let result = this.__unchecked_get(index);
+      storage.remove(this._key(this.backIndex));
+      this.backIndex -= 1;
+      return result;
+    }
+
+    /**
+     * @returns The last/back element of the deque. 
+     */
+    get back(): T {
+      return this.__get(this.length - 1);
+    }
+  }
+
+
+  /**
+   * A map class that implements a persistent unordered map.
+   */
+  export class Map<K, V> {
+    private _elementPrefix: string;
+
+    /**
+     * Creates or restores a persistent map with a given storage prefix.
+     * Always use a unique storage prefix for different collections.
+     * @param prefix A prefix to use for every key of this map.
+     */
+    constructor(prefix: string) {
+      this._elementPrefix = prefix + _KEY_ELEMENT_SUFFIX;
+    }
+
+    /**
+     * @returns An interal string key for a given key of type K.
+     */
+    @inline
+    private _key(key: K): string {
+      if (isString<K>()) {
+        return this._elementPrefix + key;
+      } else {
+        return this._elementPrefix + key.toString();
+      }
+    }
+
+    /**
+     * @param key Key to check.
+     * @returns True if the given key present in the map.
+     */
+    containsKey(key: K): bool {
+      return storage.hasKey(this._key(key));
+    }
+
+    /**
+     * Removes value and the key from the map.
+     * @param key Key to remove.
+     */
+    removeKey(key: K): void {
+      return storage.remove(this._key(key));
+    }
+
+    /**
+     * @param key Key of the element.
+     * @param defaultValue The default value if the key is not present.
+     * @returns Value for the given key or the default value.
+     */
+    @operator("[]")
+    private __get(key: K, defaultValue: V = null): V {
+      return storage.get<V>(this._key(key), defaultValue);
+    }
+
+    /**
+     * Sets the new value for the given key.
+     * @param key Key of the element.
+     * @param value The new value of the element.
+     */
+    @operator("[]=")
+    private __set(key: K, value: V): void {
+      storage.set<V>(this._key(key), value);
+    }
+  }
+
+  /**
+   * Creates or restores a persistent vector with a given storage prefix.
+   * Always use a unique storage prefix for different collections.
+   * @param prefix A prefix to use for every key of this vector.
+   */
+  export function vector<T>(prefix: string): Vector<T> {
+    return new Vector<T>(prefix);
+  }
+
+  /**
+   * Creates or restores a persistent deque with a given storage prefix.
+   * Always use a unique storage prefix for different collections.
+   * @param prefix A prefix to use for every key of this deque.
+   */
+  export function deque<T>(prefix: string): Deque<T> {
+    return new Deque<T>(prefix);
+  }
+
+  /**
+   * Creates or restores a persistent map with a given storage prefix.
+   * Always use a unique storage prefix for different collections.
+   * @param prefix A prefix to use for every key of this map.
+   */
+  export function map<K, V>(prefix: string): Map<K, V> {
+    return new Map<K, V>(prefix);
+  }
+}
 
 /**
  * Provides context for contract execution, including information about transaction sender, etc.

--- a/near.ts
+++ b/near.ts
@@ -90,7 +90,7 @@ export class Storage {
   }
 
   /**
-   * @deprecated User #remove
+   * @deprecated Use #remove
    */
   removeItem(key: string): void {
     this.remove(key);
@@ -327,7 +327,7 @@ export namespace collections {
      */
     @operator("[]=")
     private __set(index: i32, value: T): void {
-      assert(index >= 0 && index < this.length, "Index out of range");
+      assert(this.containsIndex(index), "Index out of range");
       this.__unchecked_set(index, value);
     }
 

--- a/near.ts
+++ b/near.ts
@@ -661,7 +661,6 @@ export namespace collections {
     /**
      * @returns An interal string key for a given key of type K.
      */
-    @inline
     private _key(key: K): string {
       if (isString<K>()) {
         return this._elementPrefix + key;
@@ -691,8 +690,7 @@ export namespace collections {
      * @param defaultValue The default value if the key is not present.
      * @returns Value for the given key or the default value.
      */
-    @operator("[]")
-    private __get(key: K, defaultValue: V = null): V {
+    get(key: K, defaultValue: V = null): V {
       return storage.get<V>(this._key(key), defaultValue);
     }
 
@@ -701,8 +699,7 @@ export namespace collections {
      * @param key Key of the element.
      * @param value The new value of the element.
      */
-    @operator("[]=")
-    private __set(key: K, value: V): void {
+    set(key: K, value: V): void {
       storage.set<V>(this._key(key), value);
     }
   }


### PR DESCRIPTION
There are a few changes:

1) `storage.set<T>` and `storage.get<T>`
  - allows you to set most types directly, e.g.
```
    storage.set<string>("key", "value");
    let res = storage.get<string>("key");
    storage.set<i32>("int", 42);
    let resInt = storage.get<i32>("int");
```
  - `storage.get` supports default values
```
    storage.get<string>("what", "WAT???")
```
  - set and get support encoding/decoding JSON serializable objects
```
    storage.set<Game>("key", game);
    let game = storage.get<Game>("key");
```

2) new namespace `collections` with 3 classes:
  - `collections.vector<Meme>("memes")` - a persistent vector which stores and retrives Meme objects with key prefix "memes". It takes care of serialization.
  - `collections.deque<string>("queries")` - a persistent bidirectional queue or deque. Similar to vector with contstant lookups
  - `collections.map<string, i32>("score")` - a persistent map, we already have a key-value store, so this is more like a wrapper
    Examples:
```
let memes = collections.vector<Meme>("memes");

function firstMeme(): Meme {
    return memes.first;
}

function thirdMeme(): Meme {
    return memes[2];
}

function addMeme(meme: Meme): i32 {
    return memes.push(meme); // returns index of a new element
}
```

Full working example for Guest Book (https://studio.nearprotocol.com/?f=bo4jy5hcd):
```
import "allocator/arena";
export { memory };

import { context, storage, collections, near } from "./near";

import { PostedMessage } from "./model.near";

// --- contract code goes below

const MESSAGE_LIMIT: i32 = 10;

let messages = collections.vector<PostedMessage>("m");
let testMap = collections.map<i32, PostedMessage>("ma");
let testDeque = collections.deque<PostedMessage>("d2");

export function addMessage(text: string): void {
  let message: PostedMessage = {
    sender: context.sender,
    text,
  };
  let index = messages.push(message);
  testMap[index] = message;
  if (index > 0) {
    let m = testMap[index - 1];
    near.log("Last msg " + m.toString());
  }
  if ((index % 4) == 0) {
    let i = testDeque.pushBack(message);
    near.log("Push back " + i.toString());
  } else if ((index % 4) == 1) {
    let i = testDeque.pushFront(message);
    near.log("Push front " + i.toString());
  } else if ((index % 4) == 2) {
    let m = testDeque.popBack();
    near.log("Back: " + m.toString());
  } else {
    let m = testDeque.popFront();
    near.log("Front: " + m.toString());
  }
}

// Returns an array of last N messages.
// NOTE: This is a view method. Which means it should NOT modify the state.
// Again there are no annotations for this yet.
export function getMessages(): Array<PostedMessage> {
  let limit = min(MESSAGE_LIMIT, messages.length);
  let offset = messages.length - limit;
  // Creating an dynamic size array
  let result = new Array<PostedMessage>(limit);
  // Iterating over indices of the messages. Again we need to explicitly set the type to u64
  for (let i = 0; i < limit; i++) {
    result[i] = messages[i + offset];
  }
  return result;
}

```
