### PR TITLE
Fix get<bool> in near.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+\.idea/

--- a/near.ts
+++ b/near.ts
@@ -1046,7 +1046,7 @@ export let context: Context = new Context();
 export namespace near {
 
   /**
-   * Parses given generic value from the given string.
+   * Parses the given string to return a value of the given generic type.
    * Supported types: bool, integer, string and data objects defined in model.ts.
    *
    * @param s String to parse.
@@ -1074,7 +1074,7 @@ export namespace near {
   }
 
   /**
-   * Parses given generic value from the given bytes array.
+   * Parses the given bytes array to return a value of the given generic type.
    * Supported types: bool, integer, string and data objects defined in model.ts.
    *
    * @param bytes Bytes to parse.


### PR DESCRIPTION
Fixes #12 
Also refactoring get<T> to support APIs to parse results for async calls that returns basic types. E.g. if you want to do an async call to simple sum, e.g.
```
export function sum(a: i32, b: i32): i32 {
   return a + b;
}
```
it would return you bytes array that contains a string integer, e.g. `42`. To parse it you would use a function:
```
let intResult = near.parseFromBytes<i32>(result.buffer);
```