### PR TITLE
Introducing Economics. Update the API of the promises. Replace mana/gas with balance. Expand balance API.

### DIFF
--- a/apidoc/classes/_near_.collections.deque.md
+++ b/apidoc/classes/_near_.collections.deque.md
@@ -44,7 +44,7 @@ A deque class that implements a persistent bidirectional queue.
 
 ⊕ **new Deque**(prefix: *`string`*): [Deque](_near_.collections.deque.md)
 
-*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L457)*
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L457)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L659)*
+*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L659)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L626)*
+*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L626)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L618)*
+*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L618)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L543)*
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L543)*
 
 **Returns:** `bool`
 True if the deque is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L667)*
+*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L667)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L536)*
+*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L536)*
 
 **Returns:** `i32`
 The length of the deque.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L520)*
+*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L520)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L528)*
+*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L528)*
 
 Removes the content of the element from storage without changing length of the deque.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L647)*
+*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L647)*
 
 Removes the last/back element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popFront**(): `T`
 
-*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L607)*
+*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L607)*
 
 Removes the first/front element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L635)*
+*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L635)*
 
 Adds a new element to the end of the deque. Increases the length of the deque.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushFront**(element: *`T`*): `i32`
 
-*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L596)*
+*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L596)*
 
 Adds a new element in front of the deque. Increases the length of the deque.
 

--- a/apidoc/classes/_near_.collections.deque.md
+++ b/apidoc/classes/_near_.collections.deque.md
@@ -44,7 +44,7 @@ A deque class that implements a persistent bidirectional queue.
 
 ⊕ **new Deque**(prefix: *`string`*): [Deque](_near_.collections.deque.md)
 
-*Defined in [near.ts:475](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L475)*
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L457)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -64,9 +64,9 @@ ___
 
 ###  back
 
-getback(): `T`
+**get back**(): `T`
 
-*Defined in [near.ts:677](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L677)*
+*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L659)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -76,9 +76,9 @@ ___
 
 ###  first
 
-getfirst(): `T`
+**get first**(): `T`
 
-*Defined in [near.ts:644](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L644)*
+*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L626)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -88,9 +88,9 @@ ___
 
 ###  front
 
-getfront(): `T`
+**get front**(): `T`
 
-*Defined in [near.ts:636](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L636)*
+*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L618)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -100,9 +100,9 @@ ___
 
 ###  isEmpty
 
-getisEmpty(): `bool`
+**get isEmpty**(): `bool`
 
-*Defined in [near.ts:561](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L561)*
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L543)*
 
 **Returns:** `bool`
 True if the deque is empty.
@@ -112,9 +112,9 @@ ___
 
 ###  last
 
-getlast(): `T`
+**get last**(): `T`
 
-*Defined in [near.ts:685](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L685)*
+*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L667)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -124,9 +124,9 @@ ___
 
 ###  length
 
-getlength(): `i32`
+**get length**(): `i32`
 
-*Defined in [near.ts:554](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L554)*
+*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L536)*
 
 **Returns:** `i32`
 The length of the deque.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:538](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L538)*
+*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L520)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:546](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L546)*
+*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L528)*
 
 Removes the content of the element from storage without changing length of the deque.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:665](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L665)*
+*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L647)*
 
 Removes the last/back element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popFront**(): `T`
 
-*Defined in [near.ts:625](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L625)*
+*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L607)*
 
 Removes the first/front element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:653](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L653)*
+*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L635)*
 
 Adds a new element to the end of the deque. Increases the length of the deque.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushFront**(element: *`T`*): `i32`
 
-*Defined in [near.ts:614](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L614)*
+*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L596)*
 
 Adds a new element in front of the deque. Increases the length of the deque.
 

--- a/apidoc/classes/_near_.collections.deque.md
+++ b/apidoc/classes/_near_.collections.deque.md
@@ -44,7 +44,7 @@ A deque class that implements a persistent bidirectional queue.
 
 ⊕ **new Deque**(prefix: *`string`*): [Deque](_near_.collections.deque.md)
 
-*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L457)*
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L457)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L659)*
+*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L659)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L626)*
+*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L626)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L618)*
+*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L618)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L543)*
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L543)*
 
 **Returns:** `bool`
 True if the deque is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L667)*
+*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L667)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L536)*
+*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L536)*
 
 **Returns:** `i32`
 The length of the deque.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L520)*
+*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L520)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L528)*
+*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L528)*
 
 Removes the content of the element from storage without changing length of the deque.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L647)*
+*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L647)*
 
 Removes the last/back element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popFront**(): `T`
 
-*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L607)*
+*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L607)*
 
 Removes the first/front element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L635)*
+*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L635)*
 
 Adds a new element to the end of the deque. Increases the length of the deque.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushFront**(element: *`T`*): `i32`
 
-*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L596)*
+*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L596)*
 
 Adds a new element in front of the deque. Increases the length of the deque.
 

--- a/apidoc/classes/_near_.collections.deque.md
+++ b/apidoc/classes/_near_.collections.deque.md
@@ -44,7 +44,7 @@ A deque class that implements a persistent bidirectional queue.
 
 ⊕ **new Deque**(prefix: *`string`*): [Deque](_near_.collections.deque.md)
 
-*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L457)*
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L457)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L659)*
+*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L659)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L626)*
+*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L626)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L618)*
+*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L618)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L543)*
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L543)*
 
 **Returns:** `bool`
 True if the deque is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L667)*
+*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L667)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L536)*
+*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L536)*
 
 **Returns:** `i32`
 The length of the deque.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L520)*
+*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L520)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L528)*
+*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L528)*
 
 Removes the content of the element from storage without changing length of the deque.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L647)*
+*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L647)*
 
 Removes the last/back element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popFront**(): `T`
 
-*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L607)*
+*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L607)*
 
 Removes the first/front element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L635)*
+*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L635)*
 
 Adds a new element to the end of the deque. Increases the length of the deque.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushFront**(element: *`T`*): `i32`
 
-*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L596)*
+*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L596)*
 
 Adds a new element in front of the deque. Increases the length of the deque.
 

--- a/apidoc/classes/_near_.collections.map.md
+++ b/apidoc/classes/_near_.collections.map.md
@@ -35,7 +35,7 @@ A map class that implements a persistent unordered map. NOTE: The Map doesn't st
 
 ⊕ **new Map**(prefix: *`string`*): [Map](_near_.collections.map.md)
 
-*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L678)*
+*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L678)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L718)*
+*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L718)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L726)*
+*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L726)*
 
 Removes value and the key from the map.
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **get**(key: *`K`*, defaultValue?: *`V`*): `V`
 
-*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L735)*
+*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L735)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **set**(key: *`K`*, value: *`V`*): `void`
 
-*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L744)*
+*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L744)*
 
 Sets the new value for the given key.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **values**(start?: *`K`*, end?: *`K`*, limit?: *`i32`*, startInclusive?: *`bool`*): `V`[]
 
-*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L704)*
+*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L704)*
 
 Returns values of the map between the given start key and the end key.
 

--- a/apidoc/classes/_near_.collections.map.md
+++ b/apidoc/classes/_near_.collections.map.md
@@ -35,7 +35,7 @@ A map class that implements a persistent unordered map. NOTE: The Map doesn't st
 
 ⊕ **new Map**(prefix: *`string`*): [Map](_near_.collections.map.md)
 
-*Defined in [near.ts:696](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L696)*
+*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L678)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:736](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L736)*
+*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L718)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L744)*
+*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L726)*
 
 Removes value and the key from the map.
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **get**(key: *`K`*, defaultValue?: *`V`*): `V`
 
-*Defined in [near.ts:753](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L753)*
+*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L735)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **set**(key: *`K`*, value: *`V`*): `void`
 
-*Defined in [near.ts:762](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L762)*
+*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L744)*
 
 Sets the new value for the given key.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **values**(start?: *`K`*, end?: *`K`*, limit?: *`i32`*, startInclusive?: *`bool`*): `V`[]
 
-*Defined in [near.ts:722](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L722)*
+*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L704)*
 
 Returns values of the map between the given start key and the end key.
 

--- a/apidoc/classes/_near_.collections.map.md
+++ b/apidoc/classes/_near_.collections.map.md
@@ -35,7 +35,7 @@ A map class that implements a persistent unordered map. NOTE: The Map doesn't st
 
 ⊕ **new Map**(prefix: *`string`*): [Map](_near_.collections.map.md)
 
-*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L678)*
+*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L678)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L718)*
+*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L718)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L726)*
+*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L726)*
 
 Removes value and the key from the map.
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **get**(key: *`K`*, defaultValue?: *`V`*): `V`
 
-*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L735)*
+*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L735)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **set**(key: *`K`*, value: *`V`*): `void`
 
-*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L744)*
+*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L744)*
 
 Sets the new value for the given key.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **values**(start?: *`K`*, end?: *`K`*, limit?: *`i32`*, startInclusive?: *`bool`*): `V`[]
 
-*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L704)*
+*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L704)*
 
 Returns values of the map between the given start key and the end key.
 

--- a/apidoc/classes/_near_.collections.map.md
+++ b/apidoc/classes/_near_.collections.map.md
@@ -35,7 +35,7 @@ A map class that implements a persistent unordered map. NOTE: The Map doesn't st
 
 ⊕ **new Map**(prefix: *`string`*): [Map](_near_.collections.map.md)
 
-*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L678)*
+*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L678)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L718)*
+*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L718)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L726)*
+*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L726)*
 
 Removes value and the key from the map.
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **get**(key: *`K`*, defaultValue?: *`V`*): `V`
 
-*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L735)*
+*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L735)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **set**(key: *`K`*, value: *`V`*): `void`
 
-*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L744)*
+*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L744)*
 
 Sets the new value for the given key.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **values**(start?: *`K`*, end?: *`K`*, limit?: *`i32`*, startInclusive?: *`bool`*): `V`[]
 
-*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L704)*
+*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L704)*
 
 Returns values of the map between the given start key and the end key.
 

--- a/apidoc/classes/_near_.collections.topn.md
+++ b/apidoc/classes/_near_.collections.topn.md
@@ -44,7 +44,7 @@ A TopN class that can return first N keys of a type K sorted by rating. Rating i
 
 ⊕ **new TopN**(prefix: *`string`*, descending?: *`bool`*): [TopN](_near_.collections.topn.md)
 
-*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L764)*
+*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L764)*
 
 Creates or restores a persistent top N collection with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -67,7 +67,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L808)*
+*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L808)*
 
 **Returns:** `bool`
 True if the TopN collection is empty.
@@ -79,7 +79,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L815)*
+*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L815)*
 
 **Returns:** `i32`
 The number of unique elements in the TopN collection.
@@ -94,7 +94,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L835)*
+*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L835)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L843)*
+*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L843)*
 
 Removes rating and the key from the collection.
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **getRating**(key: *`K`*, defaultRating?: *`i32`*): `i32`
 
-*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L913)*
+*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L913)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 ▸ **getTop**(limit: *`i32`*): `K`[]
 
-*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L869)*
+*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L869)*
 
 **Parameters:**
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getTopFromKey**(limit: *`i32`*, fromKey: *`K`*): `K`[]
 
-*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L880)*
+*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L880)*
 
 Returns a top list starting from the given key (exclusive). It's useful for pagination.
 
@@ -189,7 +189,7 @@ ___
 
 ▸ **getTopWithRating**(limit: *`i32`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L893)*
+*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L893)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **getTopWithRatingFromKey**(limit: *`i32`*, fromKey: *`K`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L904)*
+*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L904)*
 
 Returns a top list with rating starting from the given key (exclusive). It's useful for pagination.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **incrementRating**(key: *`K`*, increment?: *`i32`*): `void`
 
-*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L938)*
+*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L938)*
 
 Increments rating of the given key by the given increment (1 by default).
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **keysToRatings**(keys: *`K`[]*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L856)*
+*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L856)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **setRating**(key: *`K`*, rating: *`i32`*): `void`
 
-*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L922)*
+*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L922)*
 
 Sets the new rating for the given key.
 

--- a/apidoc/classes/_near_.collections.topn.md
+++ b/apidoc/classes/_near_.collections.topn.md
@@ -44,7 +44,7 @@ A TopN class that can return first N keys of a type K sorted by rating. Rating i
 
 ⊕ **new TopN**(prefix: *`string`*, descending?: *`bool`*): [TopN](_near_.collections.topn.md)
 
-*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L764)*
+*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L764)*
 
 Creates or restores a persistent top N collection with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -67,7 +67,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L808)*
+*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L808)*
 
 **Returns:** `bool`
 True if the TopN collection is empty.
@@ -79,7 +79,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L815)*
+*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L815)*
 
 **Returns:** `i32`
 The number of unique elements in the TopN collection.
@@ -94,7 +94,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L835)*
+*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L835)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L843)*
+*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L843)*
 
 Removes rating and the key from the collection.
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **getRating**(key: *`K`*, defaultRating?: *`i32`*): `i32`
 
-*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L913)*
+*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L913)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 ▸ **getTop**(limit: *`i32`*): `K`[]
 
-*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L869)*
+*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L869)*
 
 **Parameters:**
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getTopFromKey**(limit: *`i32`*, fromKey: *`K`*): `K`[]
 
-*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L880)*
+*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L880)*
 
 Returns a top list starting from the given key (exclusive). It's useful for pagination.
 
@@ -189,7 +189,7 @@ ___
 
 ▸ **getTopWithRating**(limit: *`i32`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L893)*
+*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L893)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **getTopWithRatingFromKey**(limit: *`i32`*, fromKey: *`K`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L904)*
+*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L904)*
 
 Returns a top list with rating starting from the given key (exclusive). It's useful for pagination.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **incrementRating**(key: *`K`*, increment?: *`i32`*): `void`
 
-*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L938)*
+*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L938)*
 
 Increments rating of the given key by the given increment (1 by default).
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **keysToRatings**(keys: *`K`[]*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L856)*
+*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L856)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **setRating**(key: *`K`*, rating: *`i32`*): `void`
 
-*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L922)*
+*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L922)*
 
 Sets the new rating for the given key.
 

--- a/apidoc/classes/_near_.collections.topn.md
+++ b/apidoc/classes/_near_.collections.topn.md
@@ -44,7 +44,7 @@ A TopN class that can return first N keys of a type K sorted by rating. Rating i
 
 ⊕ **new TopN**(prefix: *`string`*, descending?: *`bool`*): [TopN](_near_.collections.topn.md)
 
-*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L764)*
+*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L764)*
 
 Creates or restores a persistent top N collection with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -67,7 +67,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L808)*
+*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L808)*
 
 **Returns:** `bool`
 True if the TopN collection is empty.
@@ -79,7 +79,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L815)*
+*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L815)*
 
 **Returns:** `i32`
 The number of unique elements in the TopN collection.
@@ -94,7 +94,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L835)*
+*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L835)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L843)*
+*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L843)*
 
 Removes rating and the key from the collection.
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **getRating**(key: *`K`*, defaultRating?: *`i32`*): `i32`
 
-*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L913)*
+*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L913)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 ▸ **getTop**(limit: *`i32`*): `K`[]
 
-*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L869)*
+*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L869)*
 
 **Parameters:**
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getTopFromKey**(limit: *`i32`*, fromKey: *`K`*): `K`[]
 
-*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L880)*
+*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L880)*
 
 Returns a top list starting from the given key (exclusive). It's useful for pagination.
 
@@ -189,7 +189,7 @@ ___
 
 ▸ **getTopWithRating**(limit: *`i32`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L893)*
+*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L893)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **getTopWithRatingFromKey**(limit: *`i32`*, fromKey: *`K`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L904)*
+*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L904)*
 
 Returns a top list with rating starting from the given key (exclusive). It's useful for pagination.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **incrementRating**(key: *`K`*, increment?: *`i32`*): `void`
 
-*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L938)*
+*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L938)*
 
 Increments rating of the given key by the given increment (1 by default).
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **keysToRatings**(keys: *`K`[]*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L856)*
+*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L856)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **setRating**(key: *`K`*, rating: *`i32`*): `void`
 
-*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L922)*
+*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L922)*
 
 Sets the new rating for the given key.
 

--- a/apidoc/classes/_near_.collections.topn.md
+++ b/apidoc/classes/_near_.collections.topn.md
@@ -44,7 +44,7 @@ A TopN class that can return first N keys of a type K sorted by rating. Rating i
 
 ⊕ **new TopN**(prefix: *`string`*, descending?: *`bool`*): [TopN](_near_.collections.topn.md)
 
-*Defined in [near.ts:782](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L782)*
+*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L764)*
 
 Creates or restores a persistent top N collection with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -65,9 +65,9 @@ ___
 
 ###  isEmpty
 
-getisEmpty(): `bool`
+**get isEmpty**(): `bool`
 
-*Defined in [near.ts:826](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L826)*
+*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L808)*
 
 **Returns:** `bool`
 True if the TopN collection is empty.
@@ -77,9 +77,9 @@ ___
 
 ###  length
 
-getlength(): `i32`
+**get length**(): `i32`
 
-*Defined in [near.ts:833](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L833)*
+*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L815)*
 
 **Returns:** `i32`
 The number of unique elements in the TopN collection.
@@ -94,7 +94,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:853](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L853)*
+*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L835)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:861](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L861)*
+*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L843)*
 
 Removes rating and the key from the collection.
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **getRating**(key: *`K`*, defaultRating?: *`i32`*): `i32`
 
-*Defined in [near.ts:931](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L931)*
+*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L913)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 ▸ **getTop**(limit: *`i32`*): `K`[]
 
-*Defined in [near.ts:887](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L887)*
+*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L869)*
 
 **Parameters:**
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getTopFromKey**(limit: *`i32`*, fromKey: *`K`*): `K`[]
 
-*Defined in [near.ts:898](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L898)*
+*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L880)*
 
 Returns a top list starting from the given key (exclusive). It's useful for pagination.
 
@@ -189,7 +189,7 @@ ___
 
 ▸ **getTopWithRating**(limit: *`i32`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:911](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L911)*
+*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L893)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **getTopWithRatingFromKey**(limit: *`i32`*, fromKey: *`K`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L922)*
+*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L904)*
 
 Returns a top list with rating starting from the given key (exclusive). It's useful for pagination.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **incrementRating**(key: *`K`*, increment?: *`i32`*): `void`
 
-*Defined in [near.ts:956](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L956)*
+*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L938)*
 
 Increments rating of the given key by the given increment (1 by default).
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **keysToRatings**(keys: *`K`[]*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:874](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L874)*
+*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L856)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **setRating**(key: *`K`*, rating: *`i32`*): `void`
 
-*Defined in [near.ts:940](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L940)*
+*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L922)*
 
 Sets the new rating for the given key.
 

--- a/apidoc/classes/_near_.collections.vector.md
+++ b/apidoc/classes/_near_.collections.vector.md
@@ -44,7 +44,7 @@ A vector class that implements a persistent array.
 
 ⊕ **new Vector**(prefix: *`string`*): [Vector](_near_.collections.vector.md)
 
-*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L264)*
+*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L264)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L420)*
+*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L420)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L443)*
+*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L443)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L435)*
+*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L435)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L305)*
+*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L305)*
 
 **Returns:** `bool`
 True if the vector is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L428)*
+*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L428)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L312)*
+*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L312)*
 
 **Returns:** `i32`
 The length of the vector.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L298)*
+*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L298)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L289)*
+*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L289)*
 
 Removes the content of the element from storage without changing length of the vector.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **pop**(): `T`
 
-*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L398)*
+*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L398)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L413)*
+*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L413)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **push**(element: *`T`*): `i32`
 
-*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L376)*
+*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L376)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L389)*
+*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L389)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 

--- a/apidoc/classes/_near_.collections.vector.md
+++ b/apidoc/classes/_near_.collections.vector.md
@@ -44,7 +44,7 @@ A vector class that implements a persistent array.
 
 ⊕ **new Vector**(prefix: *`string`*): [Vector](_near_.collections.vector.md)
 
-*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L264)*
+*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L264)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L420)*
+*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L420)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L443)*
+*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L443)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L435)*
+*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L435)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L305)*
+*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L305)*
 
 **Returns:** `bool`
 True if the vector is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L428)*
+*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L428)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L312)*
+*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L312)*
 
 **Returns:** `i32`
 The length of the vector.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L298)*
+*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L298)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L289)*
+*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L289)*
 
 Removes the content of the element from storage without changing length of the vector.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **pop**(): `T`
 
-*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L398)*
+*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L398)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L413)*
+*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L413)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **push**(element: *`T`*): `i32`
 
-*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L376)*
+*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L376)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L389)*
+*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L389)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 

--- a/apidoc/classes/_near_.collections.vector.md
+++ b/apidoc/classes/_near_.collections.vector.md
@@ -44,7 +44,7 @@ A vector class that implements a persistent array.
 
 ⊕ **new Vector**(prefix: *`string`*): [Vector](_near_.collections.vector.md)
 
-*Defined in [near.ts:282](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L282)*
+*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L264)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -64,9 +64,9 @@ ___
 
 ###  back
 
-getback(): `T`
+**get back**(): `T`
 
-*Defined in [near.ts:438](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L438)*
+*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L420)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -76,9 +76,9 @@ ___
 
 ###  first
 
-getfirst(): `T`
+**get first**(): `T`
 
-*Defined in [near.ts:461](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L461)*
+*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L443)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -88,9 +88,9 @@ ___
 
 ###  front
 
-getfront(): `T`
+**get front**(): `T`
 
-*Defined in [near.ts:453](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L453)*
+*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L435)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -100,9 +100,9 @@ ___
 
 ###  isEmpty
 
-getisEmpty(): `bool`
+**get isEmpty**(): `bool`
 
-*Defined in [near.ts:323](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L323)*
+*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L305)*
 
 **Returns:** `bool`
 True if the vector is empty.
@@ -112,9 +112,9 @@ ___
 
 ###  last
 
-getlast(): `T`
+**get last**(): `T`
 
-*Defined in [near.ts:446](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L446)*
+*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L428)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -124,9 +124,9 @@ ___
 
 ###  length
 
-getlength(): `i32`
+**get length**(): `i32`
 
-*Defined in [near.ts:330](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L330)*
+*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L312)*
 
 **Returns:** `i32`
 The length of the vector.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:316](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L316)*
+*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L298)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:307](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L307)*
+*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L289)*
 
 Removes the content of the element from storage without changing length of the vector.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **pop**(): `T`
 
-*Defined in [near.ts:416](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L416)*
+*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L398)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:431](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L431)*
+*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L413)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **push**(element: *`T`*): `i32`
 
-*Defined in [near.ts:394](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L394)*
+*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L376)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:407](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L407)*
+*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L389)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 

--- a/apidoc/classes/_near_.collections.vector.md
+++ b/apidoc/classes/_near_.collections.vector.md
@@ -44,7 +44,7 @@ A vector class that implements a persistent array.
 
 ⊕ **new Vector**(prefix: *`string`*): [Vector](_near_.collections.vector.md)
 
-*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L264)*
+*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L264)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -66,7 +66,7 @@ ___
 
 **get back**(): `T`
 
-*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L420)*
+*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L420)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -78,7 +78,7 @@ ___
 
 **get first**(): `T`
 
-*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L443)*
+*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L443)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -90,7 +90,7 @@ ___
 
 **get front**(): `T`
 
-*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L435)*
+*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L435)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -102,7 +102,7 @@ ___
 
 **get isEmpty**(): `bool`
 
-*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L305)*
+*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L305)*
 
 **Returns:** `bool`
 True if the vector is empty.
@@ -114,7 +114,7 @@ ___
 
 **get last**(): `T`
 
-*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L428)*
+*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L428)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -126,7 +126,7 @@ ___
 
 **get length**(): `i32`
 
-*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L312)*
+*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L312)*
 
 **Returns:** `i32`
 The length of the vector.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L298)*
+*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L298)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L289)*
+*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L289)*
 
 Removes the content of the element from storage without changing length of the vector.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **pop**(): `T`
 
-*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L398)*
+*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L398)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L413)*
+*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L413)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **push**(element: *`T`*): `i32`
 
-*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L376)*
+*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L376)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L389)*
+*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L389)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 

--- a/apidoc/classes/_near_.context.md
+++ b/apidoc/classes/_near_.context.md
@@ -19,6 +19,7 @@ Provides context for contract execution, including information about transaction
 * [liquidBalance](_near_.context.md#liquidbalance)
 * [receivedAmount](_near_.context.md#receivedamount)
 * [sender](_near_.context.md#sender)
+* [storageUsage](_near_.context.md#storageusage)
 * [withdraw](_near_.context.md#withdraw)
 
 ---
@@ -31,7 +32,7 @@ Provides context for contract execution, including information about transaction
 
 **get blockIndex**(): `u64`
 
-*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1011)*
+*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1011)*
 
 Current block index.
 
@@ -44,7 +45,7 @@ ___
 
 **get contractName**(): `string`
 
-*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1004)*
+*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1004)*
 
 Account ID of contract.
 
@@ -57,7 +58,7 @@ ___
 
 **get deposit**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
 
-*Defined in [near.ts:1042](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1042)*
+*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1049)*
 
 Moves assets from liquid balance to frozen balance. If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible. Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
 
@@ -77,7 +78,7 @@ ___
 
 **get frozenBalance**(): `u64`
 
-*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1025)*
+*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1025)*
 
 The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
 
@@ -90,7 +91,7 @@ ___
 
 **get liquidBalance**(): `u64`
 
-*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1033)*
+*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1033)*
 
 The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
 
@@ -103,7 +104,7 @@ ___
 
 **get receivedAmount**(): `u64`
 
-*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1018)*
+*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1018)*
 
 The amount of tokens received with this execution call.
 
@@ -116,11 +117,24 @@ ___
 
 **get sender**(): `string`
 
-*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L997)*
+*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L997)*
 
 Account ID of transaction sender.
 
 **Returns:** `string`
+
+___
+<a id="storageusage"></a>
+
+###  storageUsage
+
+**get storageUsage**(): `u64`
+
+*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1040)*
+
+The current storage usage in bytes.
+
+**Returns:** `u64`
 
 ___
 <a id="withdraw"></a>
@@ -129,7 +143,7 @@ ___
 
 **get withdraw**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
 
-*Defined in [near.ts:1051](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1051)*
+*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1058)*
 
 Moves assets from frozen balance to liquid balance. If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible. Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
 

--- a/apidoc/classes/_near_.context.md
+++ b/apidoc/classes/_near_.context.md
@@ -35,7 +35,7 @@ Provides context for contract execution, including information about transaction
 
 **get blockIndex**(): `u64`
 
-*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1011)*
+*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1011)*
 
 Current block index.
 
@@ -48,7 +48,7 @@ ___
 
 **get contractName**(): `string`
 
-*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1004)*
+*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1004)*
 
 Account ID of contract.
 
@@ -61,7 +61,7 @@ ___
 
 **get frozenBalance**(): `u64`
 
-*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1025)*
+*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1025)*
 
 The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
 
@@ -74,7 +74,7 @@ ___
 
 **get liquidBalance**(): `u64`
 
-*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1033)*
+*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1033)*
 
 The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
 
@@ -87,7 +87,7 @@ ___
 
 **get receivedAmount**(): `u64`
 
-*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1018)*
+*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1018)*
 
 The amount of tokens received with this execution call.
 
@@ -100,7 +100,7 @@ ___
 
 **get sender**(): `string`
 
-*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L997)*
+*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L997)*
 
 Account ID of transaction sender.
 
@@ -113,7 +113,7 @@ ___
 
 **get storageUsage**(): `u64`
 
-*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1040)*
+*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1040)*
 
 The current storage usage in bytes.
 
@@ -127,9 +127,9 @@ ___
 
 ###  deposit
 
-▸ **deposit**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
+▸ **deposit**(minAmount: *`u64`*, maxAmount: *`u64`*): `u64`
 
-*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1049)*
+*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1049)*
 
 Moves assets from liquid balance to frozen balance. If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible. Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
 
@@ -137,8 +137,8 @@ Moves assets from liquid balance to frozen balance. If there is enough liquid ba
 
 | Name | Type |
 | ------ | ------ |
-| min_amount | `u64` |
-| max_amount | `u64` |
+| minAmount | `u64` |
+| maxAmount | `u64` |
 
 **Returns:** `u64`
 
@@ -147,9 +147,9 @@ ___
 
 ###  withdraw
 
-▸ **withdraw**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
+▸ **withdraw**(minAmount: *`u64`*, maxAmount: *`u64`*): `u64`
 
-*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1058)*
+*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1058)*
 
 Moves assets from frozen balance to liquid balance. If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible. Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
 
@@ -157,8 +157,8 @@ Moves assets from frozen balance to liquid balance. If there is enough frozen ba
 
 | Name | Type |
 | ------ | ------ |
-| min_amount | `u64` |
-| max_amount | `u64` |
+| minAmount | `u64` |
+| maxAmount | `u64` |
 
 **Returns:** `u64`
 

--- a/apidoc/classes/_near_.context.md
+++ b/apidoc/classes/_near_.context.md
@@ -14,11 +14,12 @@ Provides context for contract execution, including information about transaction
 
 * [blockIndex](_near_.context.md#blockindex)
 * [contractName](_near_.context.md#contractname)
-* [currentBalance](_near_.context.md#currentbalance)
-* [gasLeft](_near_.context.md#gasleft)
-* [manaLeft](_near_.context.md#manaleft)
+* [deposit](_near_.context.md#deposit)
+* [frozenBalance](_near_.context.md#frozenbalance)
+* [liquidBalance](_near_.context.md#liquidbalance)
 * [receivedAmount](_near_.context.md#receivedamount)
 * [sender](_near_.context.md#sender)
+* [withdraw](_near_.context.md#withdraw)
 
 ---
 
@@ -28,9 +29,9 @@ Provides context for contract execution, including information about transaction
 
 ###  blockIndex
 
-getblockIndex(): `u64`
+**get blockIndex**(): `u64`
 
-*Defined in [near.ts:1029](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1029)*
+*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1011)*
 
 Current block index.
 
@@ -41,61 +42,68 @@ ___
 
 ###  contractName
 
-getcontractName(): `string`
+**get contractName**(): `string`
 
-*Defined in [near.ts:1022](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1022)*
+*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1004)*
 
 Account ID of contract.
 
 **Returns:** `string`
 
 ___
-<a id="currentbalance"></a>
+<a id="deposit"></a>
 
-###  currentBalance
+###  deposit
 
-getcurrentBalance(): `u64`
+**get deposit**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
 
-*Defined in [near.ts:1036](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1036)*
+*Defined in [near.ts:1042](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1042)*
 
-Current balance of the contract.
+Moves assets from liquid balance to frozen balance. If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible. Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
 
-**Returns:** `u64`
+**Parameters:**
 
-___
-<a id="gasleft"></a>
-
-###  gasLeft
-
-getgasLeft(): `u64`
-
-*Defined in [near.ts:1050](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1050)*
-
-The amount of available gas left for this execution call.
+| Name | Type |
+| ------ | ------ |
+| min_amount | `u64` |
+| max_amount | `u64` |
 
 **Returns:** `u64`
 
 ___
-<a id="manaleft"></a>
+<a id="frozenbalance"></a>
 
-###  manaLeft
+###  frozenBalance
 
-getmanaLeft(): `u32`
+**get frozenBalance**(): `u64`
 
-*Defined in [near.ts:1057](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1057)*
+*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1025)*
 
-The amount of available mana left for this execution call.
+The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
 
-**Returns:** `u32`
+**Returns:** `u64`
+
+___
+<a id="liquidbalance"></a>
+
+###  liquidBalance
+
+**get liquidBalance**(): `u64`
+
+*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1033)*
+
+The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
+
+**Returns:** `u64`
 
 ___
 <a id="receivedamount"></a>
 
 ###  receivedAmount
 
-getreceivedAmount(): `u64`
+**get receivedAmount**(): `u64`
 
-*Defined in [near.ts:1043](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1043)*
+*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1018)*
 
 The amount of tokens received with this execution call.
 
@@ -106,13 +114,33 @@ ___
 
 ###  sender
 
-getsender(): `string`
+**get sender**(): `string`
 
-*Defined in [near.ts:1015](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1015)*
+*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L997)*
 
 Account ID of transaction sender.
 
 **Returns:** `string`
+
+___
+<a id="withdraw"></a>
+
+###  withdraw
+
+**get withdraw**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
+
+*Defined in [near.ts:1051](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1051)*
+
+Moves assets from frozen balance to liquid balance. If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible. Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| min_amount | `u64` |
+| max_amount | `u64` |
+
+**Returns:** `u64`
 
 ___
 

--- a/apidoc/classes/_near_.context.md
+++ b/apidoc/classes/_near_.context.md
@@ -14,12 +14,15 @@ Provides context for contract execution, including information about transaction
 
 * [blockIndex](_near_.context.md#blockindex)
 * [contractName](_near_.context.md#contractname)
-* [deposit](_near_.context.md#deposit)
 * [frozenBalance](_near_.context.md#frozenbalance)
 * [liquidBalance](_near_.context.md#liquidbalance)
 * [receivedAmount](_near_.context.md#receivedamount)
 * [sender](_near_.context.md#sender)
 * [storageUsage](_near_.context.md#storageusage)
+
+### Methods
+
+* [deposit](_near_.context.md#deposit)
 * [withdraw](_near_.context.md#withdraw)
 
 ---
@@ -32,7 +35,7 @@ Provides context for contract execution, including information about transaction
 
 **get blockIndex**(): `u64`
 
-*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1011)*
+*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1011)*
 
 Current block index.
 
@@ -45,20 +48,88 @@ ___
 
 **get contractName**(): `string`
 
-*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1004)*
+*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1004)*
 
 Account ID of contract.
 
 **Returns:** `string`
 
 ___
+<a id="frozenbalance"></a>
+
+###  frozenBalance
+
+**get frozenBalance**(): `u64`
+
+*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1025)*
+
+The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
+
+**Returns:** `u64`
+
+___
+<a id="liquidbalance"></a>
+
+###  liquidBalance
+
+**get liquidBalance**(): `u64`
+
+*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1033)*
+
+The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
+
+**Returns:** `u64`
+
+___
+<a id="receivedamount"></a>
+
+###  receivedAmount
+
+**get receivedAmount**(): `u64`
+
+*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1018)*
+
+The amount of tokens received with this execution call.
+
+**Returns:** `u64`
+
+___
+<a id="sender"></a>
+
+###  sender
+
+**get sender**(): `string`
+
+*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L997)*
+
+Account ID of transaction sender.
+
+**Returns:** `string`
+
+___
+<a id="storageusage"></a>
+
+###  storageUsage
+
+**get storageUsage**(): `u64`
+
+*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1040)*
+
+The current storage usage in bytes.
+
+**Returns:** `u64`
+
+___
+
+## Methods
+
 <a id="deposit"></a>
 
 ###  deposit
 
-**get deposit**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
+▸ **deposit**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
 
-*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1049)*
+*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1049)*
 
 Moves assets from liquid balance to frozen balance. If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible. Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
 
@@ -72,78 +143,13 @@ Moves assets from liquid balance to frozen balance. If there is enough liquid ba
 **Returns:** `u64`
 
 ___
-<a id="frozenbalance"></a>
-
-###  frozenBalance
-
-**get frozenBalance**(): `u64`
-
-*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1025)*
-
-The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
-
-**Returns:** `u64`
-
-___
-<a id="liquidbalance"></a>
-
-###  liquidBalance
-
-**get liquidBalance**(): `u64`
-
-*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1033)*
-
-The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
-
-**Returns:** `u64`
-
-___
-<a id="receivedamount"></a>
-
-###  receivedAmount
-
-**get receivedAmount**(): `u64`
-
-*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1018)*
-
-The amount of tokens received with this execution call.
-
-**Returns:** `u64`
-
-___
-<a id="sender"></a>
-
-###  sender
-
-**get sender**(): `string`
-
-*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L997)*
-
-Account ID of transaction sender.
-
-**Returns:** `string`
-
-___
-<a id="storageusage"></a>
-
-###  storageUsage
-
-**get storageUsage**(): `u64`
-
-*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1040)*
-
-The current storage usage in bytes.
-
-**Returns:** `u64`
-
-___
 <a id="withdraw"></a>
 
 ###  withdraw
 
-**get withdraw**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
+▸ **withdraw**(min_amount: *`u64`*, max_amount: *`u64`*): `u64`
 
-*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1058)*
+*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1058)*
 
 Moves assets from frozen balance to liquid balance. If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible. Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -59,7 +59,7 @@ See docs on used methods for more details.
 
 **● id**: *`i32`*
 
-*Defined in [near.ts:1271](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1271)*
+*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1278)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **returnAsResult**(): `void`
 
-*Defined in [near.ts:1375](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1375)*
+*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1382)*
 
 Returns the promise as a result of your function. Don't return any other results from the function. Your current function should be `void` and shouldn't return anything else. E.g.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, amount: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1315](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1315)*
+*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1322)*
 
 Creating a callback for the AsyncCall Promise created with `create` method.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1385](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1385)*
+*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1392)*
 
 Joins multiple async call promises into one, to aggregate results before the callback. NOTE: Given promises can only be new async calls and can't be callbacks. Joined promise can't be returned as a result
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1292](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1292)*
+*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1299)*
 
 Creates a new async call promise. Returns an instance of `ContractPromise`. The call would be scheduled if the this current execution of the contract succeeds without errors or failed asserts.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
 
-*Defined in [near.ts:1417](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1417)*
+*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1424)*
 
 Method to receive async (one or multiple) results from the remote contract in the callback. Example of using it.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -15,7 +15,6 @@ export function callMetaNear(): void {
     "addItem",
     itemArgs.encode(),
     0,
-    0,
   );
   // Setting up args for the callback
   let requestArgs: OnItemAddedArgs = {
@@ -60,7 +59,7 @@ See docs on used methods for more details.
 
 **● id**: *`i32`*
 
-*Defined in [near.ts:1219](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1219)*
+*Defined in [near.ts:1271](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1271)*
 
 ___
 
@@ -72,7 +71,7 @@ ___
 
 ▸ **returnAsResult**(): `void`
 
-*Defined in [near.ts:1326](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1326)*
+*Defined in [near.ts:1375](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1375)*
 
 Returns the promise as a result of your function. Don't return any other results from the function. Your current function should be `void` and shouldn't return anything else. E.g.
 
@@ -122,9 +121,9 @@ ___
 
 ###  then
 
-▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, mana: *`u32`*): [ContractPromise](_near_.contractpromise.md)
+▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, amount: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1266](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1266)*
+*Defined in [near.ts:1315](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1315)*
 
 Creating a callback for the AsyncCall Promise created with `create` method.
 
@@ -134,7 +133,7 @@ Creating a callback for the AsyncCall Promise created with `create` method.
 | ------ | ------ | ------ |
 | methodName | `string` |  Method name on your contract to be called to receive the callback. NOTE: Your callback method name can start with \`_\`, which would prevent other contracts from calling it directly. Only callbacks can call methods with \`_\` prefix. |
 | args | `Uint8Array` |  Serialized arguments on your callback method, see \`create\` for details. |
-| mana | `u32` |  The amount of additional requests your contract would be able to do. |
+| amount | `u64` |  The amount of tokens from the called contract to be sent to the current contract with this call. |
 
 **Returns:** [ContractPromise](_near_.contractpromise.md)
 
@@ -145,7 +144,7 @@ ___
 
 ▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1336](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1336)*
+*Defined in [near.ts:1385](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1385)*
 
 Joins multiple async call promises into one, to aggregate results before the callback. NOTE: Given promises can only be new async calls and can't be callbacks. Joined promise can't be returned as a result
 
@@ -162,9 +161,9 @@ ___
 
 ### `<Static>` create
 
-▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, mana: *`u32`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
+▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1241](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1241)*
+*Defined in [near.ts:1292](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1292)*
 
 Creates a new async call promise. Returns an instance of `ContractPromise`. The call would be scheduled if the this current execution of the contract succeeds without errors or failed asserts.
 
@@ -175,7 +174,6 @@ Creates a new async call promise. Returns an instance of `ContractPromise`. The 
 | contractName | `string` | - |  Account ID of the remote contract to call. E.g. \`metanear\`. |
 | methodName | `string` | - |  Method name on the remote contract to call. E.g. \`addItem\`. |
 | args | `Uint8Array` | - |  Serialized arguments to pass into the method. To get them create a new model specific for the method you calling, e.g. \`AddItemArgs\`. Then create an instance of it and populate arguments. After this, serialize it into bytes. E.g. ``` let itemArgs: AddItemArgs = { accountId: "alice.near", itemId: "Sword +9000", }; // Serialize args let args = itemArgs.encode(); ``` |
-| mana | `u32` | - |  The amount of additional requests the remote contract would be able to do. |
 | `Default value` amount | `u64` | 0 |  The amount of tokens from your contract to be sent to the remote contract with this call. |
 
 **Returns:** [ContractPromise](_near_.contractpromise.md)
@@ -187,7 +185,7 @@ ___
 
 ▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
 
-*Defined in [near.ts:1368](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1368)*
+*Defined in [near.ts:1417](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1417)*
 
 Method to receive async (one or multiple) results from the remote contract in the callback. Example of using it.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -59,7 +59,7 @@ See docs on used methods for more details.
 
 **● id**: *`i32`*
 
-*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1278)*
+*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1278)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **returnAsResult**(): `void`
 
-*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1382)*
+*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1382)*
 
 Returns the promise as a result of your function. Don't return any other results from the function. Your current function should be `void` and shouldn't return anything else. E.g.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, amount: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1322)*
+*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1322)*
 
 Creating a callback for the AsyncCall Promise created with `create` method.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1392)*
+*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1392)*
 
 Joins multiple async call promises into one, to aggregate results before the callback. NOTE: Given promises can only be new async calls and can't be callbacks. Joined promise can't be returned as a result
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1299)*
+*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1299)*
 
 Creates a new async call promise. Returns an instance of `ContractPromise`. The call would be scheduled if the this current execution of the contract succeeds without errors or failed asserts.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
 
-*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1424)*
+*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1424)*
 
 Method to receive async (one or multiple) results from the remote contract in the callback. Example of using it.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -59,7 +59,7 @@ See docs on used methods for more details.
 
 **● id**: *`i32`*
 
-*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1278)*
+*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1278)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **returnAsResult**(): `void`
 
-*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1382)*
+*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1382)*
 
 Returns the promise as a result of your function. Don't return any other results from the function. Your current function should be `void` and shouldn't return anything else. E.g.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, amount: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1322)*
+*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1322)*
 
 Creating a callback for the AsyncCall Promise created with `create` method.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1392)*
+*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1392)*
 
 Joins multiple async call promises into one, to aggregate results before the callback. NOTE: Given promises can only be new async calls and can't be callbacks. Joined promise can't be returned as a result
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1299)*
+*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1299)*
 
 Creates a new async call promise. Returns an instance of `ContractPromise`. The call would be scheduled if the this current execution of the contract succeeds without errors or failed asserts.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
 
-*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1424)*
+*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1424)*
 
 Method to receive async (one or multiple) results from the remote contract in the callback. Example of using it.
 

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -25,7 +25,7 @@ Class to store results of the async calls on the remote contracts.
 
 **● buffer**: *`Uint8Array`*
 
-*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1448)*
+*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1448)*
 
 ___
 <a id="success"></a>
@@ -34,7 +34,7 @@ ___
 
 **● success**: *`bool`*
 
-*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1445)*
+*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1445)*
 
 ___
 

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -25,7 +25,7 @@ Class to store results of the async calls on the remote contracts.
 
 **● buffer**: *`Uint8Array`*
 
-*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1448)*
+*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1448)*
 
 ___
 <a id="success"></a>
@@ -34,7 +34,7 @@ ___
 
 **● success**: *`bool`*
 
-*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1445)*
+*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1445)*
 
 ___
 

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -25,7 +25,7 @@ Class to store results of the async calls on the remote contracts.
 
 **● buffer**: *`Uint8Array`*
 
-*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1392)*
+*Defined in [near.ts:1441](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1441)*
 
 ___
 <a id="success"></a>
@@ -34,7 +34,7 @@ ___
 
 **● success**: *`bool`*
 
-*Defined in [near.ts:1389](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1389)*
+*Defined in [near.ts:1438](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1438)*
 
 ___
 

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -25,7 +25,7 @@ Class to store results of the async calls on the remote contracts.
 
 **● buffer**: *`Uint8Array`*
 
-*Defined in [near.ts:1441](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1441)*
+*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1448)*
 
 ___
 <a id="success"></a>
@@ -34,7 +34,7 @@ ___
 
 **● success**: *`bool`*
 
-*Defined in [near.ts:1438](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1438)*
+*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1445)*
 
 ___
 

--- a/apidoc/classes/_near_.near.mapentry.md
+++ b/apidoc/classes/_near_.near.mapentry.md
@@ -32,7 +32,7 @@ Helper class to store key->value pairs.
 
 ⊕ **new MapEntry**(key: *`K`*, value: *`V`*): [MapEntry](_near_.near.mapentry.md)
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1131)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 **● key**: *`K`*
 
-*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1130)*
+*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1130)*
 
 ___
 <a id="value"></a>
@@ -62,7 +62,7 @@ ___
 
 **● value**: *`V`*
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1131)*
 
 ___
 

--- a/apidoc/classes/_near_.near.mapentry.md
+++ b/apidoc/classes/_near_.near.mapentry.md
@@ -32,7 +32,7 @@ Helper class to store key->value pairs.
 
 ⊕ **new MapEntry**(key: *`K`*, value: *`V`*): [MapEntry](_near_.near.mapentry.md)
 
-*Defined in [near.ts:1071](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1071)*
+*Defined in [near.ts:1124](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1124)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 **● key**: *`K`*
 
-*Defined in [near.ts:1070](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1070)*
+*Defined in [near.ts:1123](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1123)*
 
 ___
 <a id="value"></a>
@@ -62,7 +62,7 @@ ___
 
 **● value**: *`V`*
 
-*Defined in [near.ts:1071](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1071)*
+*Defined in [near.ts:1124](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1124)*
 
 ___
 

--- a/apidoc/classes/_near_.near.mapentry.md
+++ b/apidoc/classes/_near_.near.mapentry.md
@@ -32,7 +32,7 @@ Helper class to store key->value pairs.
 
 ⊕ **new MapEntry**(key: *`K`*, value: *`V`*): [MapEntry](_near_.near.mapentry.md)
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1131)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 **● key**: *`K`*
 
-*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1130)*
+*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1130)*
 
 ___
 <a id="value"></a>
@@ -62,7 +62,7 @@ ___
 
 **● value**: *`V`*
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1131)*
 
 ___
 

--- a/apidoc/classes/_near_.near.mapentry.md
+++ b/apidoc/classes/_near_.near.mapentry.md
@@ -32,7 +32,7 @@ Helper class to store key->value pairs.
 
 ⊕ **new MapEntry**(key: *`K`*, value: *`V`*): [MapEntry](_near_.near.mapentry.md)
 
-*Defined in [near.ts:1124](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1124)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1131)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 **● key**: *`K`*
 
-*Defined in [near.ts:1123](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1123)*
+*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1130)*
 
 ___
 <a id="value"></a>
@@ -62,7 +62,7 @@ ___
 
 **● value**: *`V`*
 
-*Defined in [near.ts:1124](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1124)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1131)*
 
 ___
 

--- a/apidoc/classes/_near_.storage.md
+++ b/apidoc/classes/_near_.storage.md
@@ -40,7 +40,7 @@ Represents contract storage.
 
 ▸ **contains**(key: *`string`*): `bool`
 
-*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L113)*
+*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L113)*
 
 Returns true if the given key is present in the storage.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **delete**(key: *`string`*): `void`
 
-*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L122)*
+*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L122)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **get**<`T`>(key: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L185)*
+*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L185)*
 
 Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L106)*
+*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L106)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L72)*
+*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L72)*
 
 *__deprecated__*: Use getString or get
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L86)*
+*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L86)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L156)*
+*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L156)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **hasKey**(key: *`string`*): `bool`
 
-*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L118)*
+*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L118)*
 
 **Parameters:**
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **keyRange**(start: *`string`*, end: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L42)*
+*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L42)*
 
 Returns list of keys between the given start key and the end key. Both inclusive. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -217,7 +217,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L55)*
+*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L55)*
 
 Returns list of keys starting with given prefix. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **remove**(key: *`string`*): `void`
 
-*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L130)*
+*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L130)*
 
 *__deprecated__*: Use #delete
 
@@ -256,7 +256,7 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L138)*
+*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L138)*
 
 *__deprecated__*: Use #delete
 
@@ -275,7 +275,7 @@ ___
 
 ▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
 
-*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L167)*
+*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L167)*
 
 Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L96)*
+*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L96)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -320,7 +320,7 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L65)*
+*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L65)*
 
 *__deprecated__*: Use setString or set
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L79)*
+*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L79)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -360,7 +360,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L146)*
+*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L146)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/classes/_near_.storage.md
+++ b/apidoc/classes/_near_.storage.md
@@ -40,7 +40,7 @@ Represents contract storage.
 
 ▸ **contains**(key: *`string`*): `bool`
 
-*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L113)*
+*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L113)*
 
 Returns true if the given key is present in the storage.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **delete**(key: *`string`*): `void`
 
-*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L122)*
+*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L122)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **get**<`T`>(key: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L185)*
+*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L185)*
 
 Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L106)*
+*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L106)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L72)*
+*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L72)*
 
 *__deprecated__*: Use getString or get
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L86)*
+*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L86)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L156)*
+*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L156)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **hasKey**(key: *`string`*): `bool`
 
-*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L118)*
+*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L118)*
 
 **Parameters:**
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **keyRange**(start: *`string`*, end: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L42)*
+*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L42)*
 
 Returns list of keys between the given start key and the end key. Both inclusive. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -217,7 +217,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L55)*
+*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L55)*
 
 Returns list of keys starting with given prefix. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **remove**(key: *`string`*): `void`
 
-*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L130)*
+*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L130)*
 
 *__deprecated__*: Use #delete
 
@@ -256,7 +256,7 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L138)*
+*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L138)*
 
 *__deprecated__*: Use #delete
 
@@ -275,7 +275,7 @@ ___
 
 ▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
 
-*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L167)*
+*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L167)*
 
 Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L96)*
+*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L96)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -320,7 +320,7 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L65)*
+*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L65)*
 
 *__deprecated__*: Use setString or set
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L79)*
+*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L79)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -360,7 +360,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L146)*
+*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L146)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/classes/_near_.storage.md
+++ b/apidoc/classes/_near_.storage.md
@@ -40,7 +40,7 @@ Represents contract storage.
 
 ▸ **contains**(key: *`string`*): `bool`
 
-*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L113)*
+*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L113)*
 
 Returns true if the given key is present in the storage.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **delete**(key: *`string`*): `void`
 
-*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L122)*
+*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L122)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **get**<`T`>(key: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L185)*
+*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L185)*
 
 Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L106)*
+*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L106)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L72)*
+*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L72)*
 
 *__deprecated__*: Use getString or get
 
@@ -140,7 +140,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L86)*
+*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L86)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L156)*
+*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L156)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **hasKey**(key: *`string`*): `bool`
 
-*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L118)*
+*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L118)*
 
 **Parameters:**
 
@@ -196,7 +196,7 @@ ___
 
 ▸ **keyRange**(start: *`string`*, end: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L42)*
+*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L42)*
 
 Returns list of keys between the given start key and the end key. Both inclusive. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -217,7 +217,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L55)*
+*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L55)*
 
 Returns list of keys starting with given prefix. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -237,7 +237,7 @@ ___
 
 ▸ **remove**(key: *`string`*): `void`
 
-*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L130)*
+*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L130)*
 
 *__deprecated__*: Use #delete
 
@@ -256,7 +256,7 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L138)*
+*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L138)*
 
 *__deprecated__*: Use #delete
 
@@ -275,7 +275,7 @@ ___
 
 ▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
 
-*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L167)*
+*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L167)*
 
 Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L96)*
+*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L96)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -320,7 +320,7 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L65)*
+*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L65)*
 
 *__deprecated__*: Use setString or set
 
@@ -340,7 +340,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L79)*
+*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L79)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -360,7 +360,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L146)*
+*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L146)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/classes/_near_.storage.md
+++ b/apidoc/classes/_near_.storage.md
@@ -40,7 +40,7 @@ Represents contract storage.
 
 ▸ **contains**(key: *`string`*): `bool`
 
-*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L113)*
+*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L113)*
 
 Returns true if the given key is present in the storage.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **delete**(key: *`string`*): `void`
 
-*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L122)*
+*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L122)*
 
 **Parameters:**
 
@@ -76,9 +76,9 @@ ___
 
 ▸ **get**<`T`>(key: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:186](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L186)*
+*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L185)*
 
-Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bools, integers, string and data objects defined in model.ts. For common/dynamic arrays use {@link #getArray}
+Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
 **Type parameters:**
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L106)*
+*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L106)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -121,10 +121,9 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L72)*
+*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L72)*
 
-*__deprecated__*:
- Use getString or get
+*__deprecated__*: Use getString or get
 
 **Parameters:**
 
@@ -141,7 +140,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L86)*
+*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L86)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -160,7 +159,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L156)*
+*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L156)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -180,7 +179,7 @@ ___
 
 ▸ **hasKey**(key: *`string`*): `bool`
 
-*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L118)*
+*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L118)*
 
 **Parameters:**
 
@@ -197,7 +196,7 @@ ___
 
 ▸ **keyRange**(start: *`string`*, end: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L42)*
+*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L42)*
 
 Returns list of keys between the given start key and the end key. Both inclusive. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -218,7 +217,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L55)*
+*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L55)*
 
 Returns list of keys starting with given prefix. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -238,10 +237,9 @@ ___
 
 ▸ **remove**(key: *`string`*): `void`
 
-*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L130)*
+*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L130)*
 
-*__deprecated__*:
- Use #delete
+*__deprecated__*: Use #delete
 
 **Parameters:**
 
@@ -258,10 +256,9 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L138)*
+*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L138)*
 
-*__deprecated__*:
- Use #delete
+*__deprecated__*: Use #delete
 
 **Parameters:**
 
@@ -278,9 +275,9 @@ ___
 
 ▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
 
-*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L167)*
+*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L167)*
 
-Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bools, integers, string and data objects defined in model.ts.
+Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
 **Type parameters:**
 
@@ -301,7 +298,7 @@ ___
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L96)*
+*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L96)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -323,10 +320,9 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L65)*
+*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L65)*
 
-*__deprecated__*:
- Use setString or set
+*__deprecated__*: Use setString or set
 
 **Parameters:**
 
@@ -344,7 +340,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L79)*
+*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L79)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -364,7 +360,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L146)*
+*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L146)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/modules/_near_.base64.md
+++ b/apidoc/modules/_near_.base64.md
@@ -1,0 +1,101 @@
+[near-runtime-ts](../README.md) > ["near"](../modules/_near_.md) > [base64](../modules/_near_.base64.md)
+
+# Module: base64
+
+base64 encoding/decoding
+
+## Index
+
+### Variables
+
+* [ALPHA](_near_.base64.md#alpha)
+* [PADCHAR](_near_.base64.md#padchar)
+
+### Functions
+
+* [decode](_near_.base64.md#decode)
+* [encode](_near_.base64.md#encode)
+* [getByte64](_near_.base64.md#getbyte64)
+
+---
+
+## Variables
+
+<a id="alpha"></a>
+
+### `<Const>` ALPHA
+
+**● ALPHA**: *`string`* = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+*Defined in [near.ts:1561](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1561)*
+
+___
+<a id="padchar"></a>
+
+### `<Const>` PADCHAR
+
+**● PADCHAR**: *`string`* = "="
+
+*Defined in [near.ts:1560](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1560)*
+
+___
+
+## Functions
+
+<a id="decode"></a>
+
+###  decode
+
+▸ **decode**(s: *`string`*): `Uint8Array`
+
+*Defined in [near.ts:1571](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1571)*
+
+Decode base64-encoded string and return a Uint8Array.
+
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| s | `string` |  Base64 encoded string. |
+
+**Returns:** `Uint8Array`
+
+___
+<a id="encode"></a>
+
+###  encode
+
+▸ **encode**(bytes: *`Uint8Array`*): `string`
+
+*Defined in [near.ts:1620](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1620)*
+
+Encode Uint8Array in base64.
+
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| bytes | `Uint8Array` |  Byte array of type Uint8Array. |
+
+**Returns:** `string`
+
+___
+<a id="getbyte64"></a>
+
+###  getByte64
+
+▸ **getByte64**(s: *`string`*, i: *`u32`*): `u32`
+
+*Defined in [near.ts:1563](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1563)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| s | `string` |
+| i | `u32` |
+
+**Returns:** `u32`
+
+___
+

--- a/apidoc/modules/_near_.base64.md
+++ b/apidoc/modules/_near_.base64.md
@@ -27,7 +27,7 @@ base64 encoding/decoding
 
 **● ALPHA**: *`string`* = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1574)*
+*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1574)*
 
 ___
 <a id="padchar"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PADCHAR**: *`string`* = "="
 
-*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1573)*
+*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1573)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **decode**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1584)*
+*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1584)*
 
 Decode base64-encoded string and return a Uint8Array.
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **encode**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1633)*
+*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1633)*
 
 Encode Uint8Array in base64.
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **getByte64**(s: *`string`*, i: *`u32`*): `u32`
 
-*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1576)*
+*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1576)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.base64.md
+++ b/apidoc/modules/_near_.base64.md
@@ -27,7 +27,7 @@ base64 encoding/decoding
 
 **● ALPHA**: *`string`* = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1574)*
+*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1574)*
 
 ___
 <a id="padchar"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PADCHAR**: *`string`* = "="
 
-*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1573)*
+*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1573)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **decode**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1584)*
+*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1584)*
 
 Decode base64-encoded string and return a Uint8Array.
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **encode**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1633)*
+*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1633)*
 
 Encode Uint8Array in base64.
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **getByte64**(s: *`string`*, i: *`u32`*): `u32`
 
-*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1576)*
+*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1576)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.base64.md
+++ b/apidoc/modules/_near_.base64.md
@@ -27,7 +27,7 @@ base64 encoding/decoding
 
 **● ALPHA**: *`string`* = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-*Defined in [near.ts:1561](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1561)*
+*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1574)*
 
 ___
 <a id="padchar"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PADCHAR**: *`string`* = "="
 
-*Defined in [near.ts:1560](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1560)*
+*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1573)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **decode**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1571](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1571)*
+*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1584)*
 
 Decode base64-encoded string and return a Uint8Array.
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **encode**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1620](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1620)*
+*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1633)*
 
 Encode Uint8Array in base64.
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **getByte64**(s: *`string`*, i: *`u32`*): `u32`
 
-*Defined in [near.ts:1563](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1563)*
+*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1576)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.collections.md
+++ b/apidoc/modules/_near_.collections.md
@@ -39,7 +39,7 @@ A namespace with classes and functions for persistent collections on the blockch
 
 **● _KEY_BACK_INDEX_SUFFIX**: *":back"* = ":back"
 
-*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L253)*
+*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L253)*
 
 ___
 <a id="_key_element_suffix"></a>
@@ -48,7 +48,7 @@ ___
 
 **● _KEY_ELEMENT_SUFFIX**: *"::"* = "::"
 
-*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L254)*
+*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L254)*
 
 ___
 <a id="_key_front_index_suffix"></a>
@@ -57,7 +57,7 @@ ___
 
 **● _KEY_FRONT_INDEX_SUFFIX**: *":front"* = ":front"
 
-*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L252)*
+*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L252)*
 
 ___
 <a id="_key_length_suffix"></a>
@@ -66,7 +66,7 @@ ___
 
 **● _KEY_LENGTH_SUFFIX**: *":len"* = ":len"
 
-*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L251)*
+*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L251)*
 
 ___
 <a id="_key_rating_suffix"></a>
@@ -75,7 +75,7 @@ ___
 
 **● _KEY_RATING_SUFFIX**: *":r"* = ":r"
 
-*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L255)*
+*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L255)*
 
 ___
 <a id="_rating_offset"></a>
@@ -84,7 +84,7 @@ ___
 
 **● _RATING_OFFSET**: *`u64`* = 2147483648
 
-*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L256)*
+*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L256)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **deque**<`T`>(prefix: *`string`*): [Deque](../classes/_near_.collections.deque.md)<`T`>
 
-*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L966)*
+*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L966)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **map**<`K`,`V`>(prefix: *`string`*): [Map](../classes/_near_.collections.map.md)<`K`, `V`>
 
-*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L975)*
+*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L975)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **topN**<`K`>(prefix: *`string`*, descending?: *`bool`*): [TopN](../classes/_near_.collections.topn.md)<`K`>
 
-*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L985)*
+*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L985)*
 
 Creates or restores a persistent TopN with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **vector**<`T`>(prefix: *`string`*): [Vector](../classes/_near_.collections.vector.md)<`T`>
 
-*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L957)*
+*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L957)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 

--- a/apidoc/modules/_near_.collections.md
+++ b/apidoc/modules/_near_.collections.md
@@ -39,7 +39,7 @@ A namespace with classes and functions for persistent collections on the blockch
 
 **● _KEY_BACK_INDEX_SUFFIX**: *":back"* = ":back"
 
-*Defined in [near.ts:271](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L271)*
+*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L253)*
 
 ___
 <a id="_key_element_suffix"></a>
@@ -48,7 +48,7 @@ ___
 
 **● _KEY_ELEMENT_SUFFIX**: *"::"* = "::"
 
-*Defined in [near.ts:272](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L272)*
+*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L254)*
 
 ___
 <a id="_key_front_index_suffix"></a>
@@ -57,7 +57,7 @@ ___
 
 **● _KEY_FRONT_INDEX_SUFFIX**: *":front"* = ":front"
 
-*Defined in [near.ts:270](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L270)*
+*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L252)*
 
 ___
 <a id="_key_length_suffix"></a>
@@ -66,7 +66,7 @@ ___
 
 **● _KEY_LENGTH_SUFFIX**: *":len"* = ":len"
 
-*Defined in [near.ts:269](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L269)*
+*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L251)*
 
 ___
 <a id="_key_rating_suffix"></a>
@@ -75,7 +75,7 @@ ___
 
 **● _KEY_RATING_SUFFIX**: *":r"* = ":r"
 
-*Defined in [near.ts:273](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L273)*
+*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L255)*
 
 ___
 <a id="_rating_offset"></a>
@@ -84,7 +84,7 @@ ___
 
 **● _RATING_OFFSET**: *`u64`* = 2147483648
 
-*Defined in [near.ts:274](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L274)*
+*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L256)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **deque**<`T`>(prefix: *`string`*): [Deque](../classes/_near_.collections.deque.md)<`T`>
 
-*Defined in [near.ts:984](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L984)*
+*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L966)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **map**<`K`,`V`>(prefix: *`string`*): [Map](../classes/_near_.collections.map.md)<`K`, `V`>
 
-*Defined in [near.ts:993](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L993)*
+*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L975)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **topN**<`K`>(prefix: *`string`*, descending?: *`bool`*): [TopN](../classes/_near_.collections.topn.md)<`K`>
 
-*Defined in [near.ts:1003](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1003)*
+*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L985)*
 
 Creates or restores a persistent TopN with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **vector**<`T`>(prefix: *`string`*): [Vector](../classes/_near_.collections.vector.md)<`T`>
 
-*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L975)*
+*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L957)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 

--- a/apidoc/modules/_near_.collections.md
+++ b/apidoc/modules/_near_.collections.md
@@ -39,7 +39,7 @@ A namespace with classes and functions for persistent collections on the blockch
 
 **● _KEY_BACK_INDEX_SUFFIX**: *":back"* = ":back"
 
-*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L253)*
+*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L253)*
 
 ___
 <a id="_key_element_suffix"></a>
@@ -48,7 +48,7 @@ ___
 
 **● _KEY_ELEMENT_SUFFIX**: *"::"* = "::"
 
-*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L254)*
+*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L254)*
 
 ___
 <a id="_key_front_index_suffix"></a>
@@ -57,7 +57,7 @@ ___
 
 **● _KEY_FRONT_INDEX_SUFFIX**: *":front"* = ":front"
 
-*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L252)*
+*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L252)*
 
 ___
 <a id="_key_length_suffix"></a>
@@ -66,7 +66,7 @@ ___
 
 **● _KEY_LENGTH_SUFFIX**: *":len"* = ":len"
 
-*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L251)*
+*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L251)*
 
 ___
 <a id="_key_rating_suffix"></a>
@@ -75,7 +75,7 @@ ___
 
 **● _KEY_RATING_SUFFIX**: *":r"* = ":r"
 
-*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L255)*
+*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L255)*
 
 ___
 <a id="_rating_offset"></a>
@@ -84,7 +84,7 @@ ___
 
 **● _RATING_OFFSET**: *`u64`* = 2147483648
 
-*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L256)*
+*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L256)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **deque**<`T`>(prefix: *`string`*): [Deque](../classes/_near_.collections.deque.md)<`T`>
 
-*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L966)*
+*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L966)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **map**<`K`,`V`>(prefix: *`string`*): [Map](../classes/_near_.collections.map.md)<`K`, `V`>
 
-*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L975)*
+*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L975)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **topN**<`K`>(prefix: *`string`*, descending?: *`bool`*): [TopN](../classes/_near_.collections.topn.md)<`K`>
 
-*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L985)*
+*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L985)*
 
 Creates or restores a persistent TopN with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **vector**<`T`>(prefix: *`string`*): [Vector](../classes/_near_.collections.vector.md)<`T`>
 
-*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L957)*
+*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L957)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 

--- a/apidoc/modules/_near_.collections.md
+++ b/apidoc/modules/_near_.collections.md
@@ -39,7 +39,7 @@ A namespace with classes and functions for persistent collections on the blockch
 
 **● _KEY_BACK_INDEX_SUFFIX**: *":back"* = ":back"
 
-*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L253)*
+*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L253)*
 
 ___
 <a id="_key_element_suffix"></a>
@@ -48,7 +48,7 @@ ___
 
 **● _KEY_ELEMENT_SUFFIX**: *"::"* = "::"
 
-*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L254)*
+*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L254)*
 
 ___
 <a id="_key_front_index_suffix"></a>
@@ -57,7 +57,7 @@ ___
 
 **● _KEY_FRONT_INDEX_SUFFIX**: *":front"* = ":front"
 
-*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L252)*
+*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L252)*
 
 ___
 <a id="_key_length_suffix"></a>
@@ -66,7 +66,7 @@ ___
 
 **● _KEY_LENGTH_SUFFIX**: *":len"* = ":len"
 
-*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L251)*
+*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L251)*
 
 ___
 <a id="_key_rating_suffix"></a>
@@ -75,7 +75,7 @@ ___
 
 **● _KEY_RATING_SUFFIX**: *":r"* = ":r"
 
-*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L255)*
+*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L255)*
 
 ___
 <a id="_rating_offset"></a>
@@ -84,7 +84,7 @@ ___
 
 **● _RATING_OFFSET**: *`u64`* = 2147483648
 
-*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L256)*
+*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L256)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **deque**<`T`>(prefix: *`string`*): [Deque](../classes/_near_.collections.deque.md)<`T`>
 
-*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L966)*
+*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L966)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **map**<`K`,`V`>(prefix: *`string`*): [Map](../classes/_near_.collections.map.md)<`K`, `V`>
 
-*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L975)*
+*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L975)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **topN**<`K`>(prefix: *`string`*, descending?: *`bool`*): [TopN](../classes/_near_.collections.topn.md)<`K`>
 
-*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L985)*
+*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L985)*
 
 Creates or restores a persistent TopN with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **vector**<`T`>(prefix: *`string`*): [Vector](../classes/_near_.collections.vector.md)<`T`>
 
-*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L957)*
+*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L957)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -60,7 +60,7 @@
 
 **Ƭ DataTypeIndex**: *`u32`*
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L3)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 **● DATA_TYPE_CURRENT_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 2
 
-*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L6)*
+*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L6)*
 
 ___
 <a id="data_type_input"></a>
@@ -81,7 +81,7 @@ ___
 
 **● DATA_TYPE_INPUT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 4
 
-*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L8)*
+*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L8)*
 
 ___
 <a id="data_type_originator_account_id"></a>
@@ -90,7 +90,7 @@ ___
 
 **● DATA_TYPE_ORIGINATOR_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 1
 
-*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L5)*
+*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L5)*
 
 ___
 <a id="data_type_result"></a>
@@ -99,7 +99,7 @@ ___
 
 **● DATA_TYPE_RESULT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 5
 
-*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L9)*
+*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L9)*
 
 ___
 <a id="data_type_storage"></a>
@@ -108,7 +108,7 @@ ___
 
 **● DATA_TYPE_STORAGE**: *[DataTypeIndex](_near_.md#datatypeindex)* = 3
 
-*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L7)*
+*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L7)*
 
 ___
 <a id="data_type_storage_iter"></a>
@@ -117,7 +117,7 @@ ___
 
 **● DATA_TYPE_STORAGE_ITER**: *[DataTypeIndex](_near_.md#datatypeindex)* = 6
 
-*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L10)*
+*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L10)*
 
 ___
 <a id="default_scratch_buffer_size"></a>
@@ -126,7 +126,7 @@ ___
 
 **● DEFAULT_SCRATCH_BUFFER_SIZE**: *`usize`* =  1 << 16
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1)*
 
 ___
 <a id="context-1"></a>
@@ -135,7 +135,7 @@ ___
 
 **● context**: *[Context](../classes/_near_.context.md)* =  new Context()
 
-*Defined in [near.ts:1056](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1056)*
+*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1063)*
 
 ___
 <a id="storage-1"></a>
@@ -144,7 +144,7 @@ ___
 
 **● storage**: *[Storage](../classes/_near_.storage.md)* =  new Storage()
 
-*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L245)*
+*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L245)*
 
 An instance of a Storage class that is used for working with contract storage on the blockchain.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **data_read**(type_index: *`u32`*, key_len: *`usize`*, key: *`usize`*, max_buf_len: *`usize`*, buf_ptr: *`usize`*): `usize`
 
-*Defined in [near.ts:1468](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1468)*
+*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1475)*
 
 **Parameters:**
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
 
-*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1485)*
+*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1492)*
 
 **Parameters:**
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1471](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1471)*
+*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1478)*
 
 **Parameters:**
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1478)*
+*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1485)*
 
 **Parameters:**
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **result_count**(): `u32`
 
-*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1458)*
+*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1465)*
 
 **Returns:** `u32`
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **result_is_ok**(index: *`u32`*): `bool`
 
-*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1460)*
+*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1467)*
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **return_promise**(promise_index: *`u32`*): `void`
 
-*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1465)*
+*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1472)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **return_value**(value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1463](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1463)*
+*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1470)*
 
 **Parameters:**
 
@@ -305,7 +305,7 @@ ___
 
 ▸ **storage_has_key**(key_len: *`usize`*, key_ptr: *`usize`*): `bool`
 
-*Defined in [near.ts:1449](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1449)*
+*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1456)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **storage_iter**(prefix_len: *`usize`*, prefix_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1451](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1451)*
+*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1458)*
 
 **Parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:1455](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1455)*
+*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1462)*
 
 **Parameters:**
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **storage_range**(start_len: *`usize`*, start_ptr: *`usize`*, end_len: *`usize`*, end_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1453](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1453)*
+*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1460)*
 
 **Parameters:**
 
@@ -378,7 +378,7 @@ ___
 
 ▸ **storage_remove**(key_len: *`usize`*, key_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1447](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1447)*
+*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1454)*
 
 **Parameters:**
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **storage_write**(key_len: *`usize`*, key_ptr: *`usize`*, value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1445)*
+*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1452)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -60,7 +60,7 @@
 
 **Ƭ DataTypeIndex**: *`u32`*
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L3)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 **● DATA_TYPE_CURRENT_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 2
 
-*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L6)*
+*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L6)*
 
 ___
 <a id="data_type_input"></a>
@@ -81,7 +81,7 @@ ___
 
 **● DATA_TYPE_INPUT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 4
 
-*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L8)*
+*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L8)*
 
 ___
 <a id="data_type_originator_account_id"></a>
@@ -90,7 +90,7 @@ ___
 
 **● DATA_TYPE_ORIGINATOR_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 1
 
-*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L5)*
+*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L5)*
 
 ___
 <a id="data_type_result"></a>
@@ -99,7 +99,7 @@ ___
 
 **● DATA_TYPE_RESULT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 5
 
-*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L9)*
+*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L9)*
 
 ___
 <a id="data_type_storage"></a>
@@ -108,7 +108,7 @@ ___
 
 **● DATA_TYPE_STORAGE**: *[DataTypeIndex](_near_.md#datatypeindex)* = 3
 
-*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L7)*
+*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L7)*
 
 ___
 <a id="data_type_storage_iter"></a>
@@ -117,7 +117,7 @@ ___
 
 **● DATA_TYPE_STORAGE_ITER**: *[DataTypeIndex](_near_.md#datatypeindex)* = 6
 
-*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L10)*
+*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L10)*
 
 ___
 <a id="default_scratch_buffer_size"></a>
@@ -126,7 +126,7 @@ ___
 
 **● DEFAULT_SCRATCH_BUFFER_SIZE**: *`usize`* =  1 << 16
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1)*
 
 ___
 <a id="context-1"></a>
@@ -135,7 +135,7 @@ ___
 
 **● context**: *[Context](../classes/_near_.context.md)* =  new Context()
 
-*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1063)*
+*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1063)*
 
 ___
 <a id="storage-1"></a>
@@ -144,7 +144,7 @@ ___
 
 **● storage**: *[Storage](../classes/_near_.storage.md)* =  new Storage()
 
-*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L245)*
+*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L245)*
 
 An instance of a Storage class that is used for working with contract storage on the blockchain.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **data_read**(type_index: *`u32`*, key_len: *`usize`*, key: *`usize`*, max_buf_len: *`usize`*, buf_ptr: *`usize`*): `usize`
 
-*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1475)*
+*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1475)*
 
 **Parameters:**
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
 
-*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1492)*
+*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1492)*
 
 **Parameters:**
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1478)*
+*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1478)*
 
 **Parameters:**
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1485)*
+*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1485)*
 
 **Parameters:**
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **result_count**(): `u32`
 
-*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1465)*
+*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1465)*
 
 **Returns:** `u32`
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **result_is_ok**(index: *`u32`*): `bool`
 
-*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1467)*
+*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1467)*
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **return_promise**(promise_index: *`u32`*): `void`
 
-*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1472)*
+*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1472)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **return_value**(value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1470)*
+*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1470)*
 
 **Parameters:**
 
@@ -305,7 +305,7 @@ ___
 
 ▸ **storage_has_key**(key_len: *`usize`*, key_ptr: *`usize`*): `bool`
 
-*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1456)*
+*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1456)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **storage_iter**(prefix_len: *`usize`*, prefix_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1458)*
+*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1458)*
 
 **Parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1462)*
+*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1462)*
 
 **Parameters:**
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **storage_range**(start_len: *`usize`*, start_ptr: *`usize`*, end_len: *`usize`*, end_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1460)*
+*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1460)*
 
 **Parameters:**
 
@@ -378,7 +378,7 @@ ___
 
 ▸ **storage_remove**(key_len: *`usize`*, key_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1454)*
+*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1454)*
 
 **Parameters:**
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **storage_write**(key_len: *`usize`*, key_ptr: *`usize`*, value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1452)*
+*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1452)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -60,7 +60,7 @@
 
 **Ƭ DataTypeIndex**: *`u32`*
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L3)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 **● DATA_TYPE_CURRENT_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 2
 
-*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L6)*
+*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L6)*
 
 ___
 <a id="data_type_input"></a>
@@ -81,7 +81,7 @@ ___
 
 **● DATA_TYPE_INPUT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 4
 
-*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L8)*
+*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L8)*
 
 ___
 <a id="data_type_originator_account_id"></a>
@@ -90,7 +90,7 @@ ___
 
 **● DATA_TYPE_ORIGINATOR_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 1
 
-*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L5)*
+*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L5)*
 
 ___
 <a id="data_type_result"></a>
@@ -99,7 +99,7 @@ ___
 
 **● DATA_TYPE_RESULT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 5
 
-*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L9)*
+*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L9)*
 
 ___
 <a id="data_type_storage"></a>
@@ -108,7 +108,7 @@ ___
 
 **● DATA_TYPE_STORAGE**: *[DataTypeIndex](_near_.md#datatypeindex)* = 3
 
-*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L7)*
+*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L7)*
 
 ___
 <a id="data_type_storage_iter"></a>
@@ -117,7 +117,7 @@ ___
 
 **● DATA_TYPE_STORAGE_ITER**: *[DataTypeIndex](_near_.md#datatypeindex)* = 6
 
-*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L10)*
+*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L10)*
 
 ___
 <a id="default_scratch_buffer_size"></a>
@@ -126,7 +126,7 @@ ___
 
 **● DEFAULT_SCRATCH_BUFFER_SIZE**: *`usize`* =  1 << 16
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1)*
 
 ___
 <a id="context-1"></a>
@@ -135,7 +135,7 @@ ___
 
 **● context**: *[Context](../classes/_near_.context.md)* =  new Context()
 
-*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1063)*
+*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1063)*
 
 ___
 <a id="storage-1"></a>
@@ -144,7 +144,7 @@ ___
 
 **● storage**: *[Storage](../classes/_near_.storage.md)* =  new Storage()
 
-*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L245)*
+*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L245)*
 
 An instance of a Storage class that is used for working with contract storage on the blockchain.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **data_read**(type_index: *`u32`*, key_len: *`usize`*, key: *`usize`*, max_buf_len: *`usize`*, buf_ptr: *`usize`*): `usize`
 
-*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1475)*
+*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1475)*
 
 **Parameters:**
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
 
-*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1492)*
+*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1492)*
 
 **Parameters:**
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1478)*
+*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1478)*
 
 **Parameters:**
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1485)*
+*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1485)*
 
 **Parameters:**
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **result_count**(): `u32`
 
-*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1465)*
+*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1465)*
 
 **Returns:** `u32`
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **result_is_ok**(index: *`u32`*): `bool`
 
-*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1467)*
+*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1467)*
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **return_promise**(promise_index: *`u32`*): `void`
 
-*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1472)*
+*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1472)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **return_value**(value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1470)*
+*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1470)*
 
 **Parameters:**
 
@@ -305,7 +305,7 @@ ___
 
 ▸ **storage_has_key**(key_len: *`usize`*, key_ptr: *`usize`*): `bool`
 
-*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1456)*
+*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1456)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **storage_iter**(prefix_len: *`usize`*, prefix_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1458)*
+*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1458)*
 
 **Parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1462)*
+*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1462)*
 
 **Parameters:**
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **storage_range**(start_len: *`usize`*, start_ptr: *`usize`*, end_len: *`usize`*, end_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1460)*
+*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1460)*
 
 **Parameters:**
 
@@ -378,7 +378,7 @@ ___
 
 ▸ **storage_remove**(key_len: *`usize`*, key_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1454)*
+*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1454)*
 
 **Parameters:**
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **storage_write**(key_len: *`usize`*, key_ptr: *`usize`*, value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1452)*
+*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1452)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -6,6 +6,7 @@
 
 ### Modules
 
+* [base64](_near_.base64.md)
 * [collections](_near_.collections.md)
 * [near](_near_.near.md)
 
@@ -59,7 +60,7 @@
 
 **Ƭ DataTypeIndex**: *`u32`*
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L3)*
 
 ___
 
@@ -71,7 +72,7 @@ ___
 
 **● DATA_TYPE_CURRENT_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 2
 
-*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L6)*
+*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L6)*
 
 ___
 <a id="data_type_input"></a>
@@ -80,7 +81,7 @@ ___
 
 **● DATA_TYPE_INPUT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 4
 
-*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L8)*
+*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L8)*
 
 ___
 <a id="data_type_originator_account_id"></a>
@@ -89,7 +90,7 @@ ___
 
 **● DATA_TYPE_ORIGINATOR_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 1
 
-*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L5)*
+*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L5)*
 
 ___
 <a id="data_type_result"></a>
@@ -98,7 +99,7 @@ ___
 
 **● DATA_TYPE_RESULT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 5
 
-*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L9)*
+*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L9)*
 
 ___
 <a id="data_type_storage"></a>
@@ -107,7 +108,7 @@ ___
 
 **● DATA_TYPE_STORAGE**: *[DataTypeIndex](_near_.md#datatypeindex)* = 3
 
-*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L7)*
+*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L7)*
 
 ___
 <a id="data_type_storage_iter"></a>
@@ -116,7 +117,7 @@ ___
 
 **● DATA_TYPE_STORAGE_ITER**: *[DataTypeIndex](_near_.md#datatypeindex)* = 6
 
-*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L10)*
+*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L10)*
 
 ___
 <a id="default_scratch_buffer_size"></a>
@@ -125,7 +126,7 @@ ___
 
 **● DEFAULT_SCRATCH_BUFFER_SIZE**: *`usize`* =  1 << 16
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1)*
 
 ___
 <a id="context-1"></a>
@@ -134,7 +135,7 @@ ___
 
 **● context**: *[Context](../classes/_near_.context.md)* =  new Context()
 
-*Defined in [near.ts:1062](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1062)*
+*Defined in [near.ts:1056](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1056)*
 
 ___
 <a id="storage-1"></a>
@@ -143,7 +144,7 @@ ___
 
 **● storage**: *[Storage](../classes/_near_.storage.md)* =  new Storage()
 
-*Defined in [near.ts:263](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L263)*
+*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L245)*
 
 An instance of a Storage class that is used for working with contract storage on the blockchain.
 
@@ -157,7 +158,7 @@ ___
 
 ▸ **data_read**(type_index: *`u32`*, key_len: *`usize`*, key: *`usize`*, max_buf_len: *`usize`*, buf_ptr: *`usize`*): `usize`
 
-*Defined in [near.ts:1419](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1419)*
+*Defined in [near.ts:1468](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1468)*
 
 **Parameters:**
 
@@ -178,7 +179,7 @@ ___
 
 ▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
 
-*Defined in [near.ts:1437](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1437)*
+*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1485)*
 
 **Parameters:**
 
@@ -194,9 +195,9 @@ ___
 
 ###  promise_create
 
-▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, mana: *`u32`*, amount: *`u64`*): `u32`
+▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1422](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1422)*
+*Defined in [near.ts:1471](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1471)*
 
 **Parameters:**
 
@@ -208,7 +209,6 @@ ___
 | method_name_ptr | `usize` |
 | args_len | `usize` |
 | args_ptr | `usize` |
-| mana | `u32` |
 | amount | `u64` |
 
 **Returns:** `u32`
@@ -218,9 +218,9 @@ ___
 
 ###  promise_then
 
-▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, mana: *`u32`*): `u32`
+▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1430](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1430)*
+*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1478)*
 
 **Parameters:**
 
@@ -231,7 +231,7 @@ ___
 | method_name_ptr | `usize` |
 | args_len | `usize` |
 | args_ptr | `usize` |
-| mana | `u32` |
+| amount | `u64` |
 
 **Returns:** `u32`
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **result_count**(): `u32`
 
-*Defined in [near.ts:1409](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1409)*
+*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1458)*
 
 **Returns:** `u32`
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **result_is_ok**(index: *`u32`*): `bool`
 
-*Defined in [near.ts:1411](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1411)*
+*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1460)*
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **return_promise**(promise_index: *`u32`*): `void`
 
-*Defined in [near.ts:1416](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1416)*
+*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1465)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **return_value**(value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1414](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1414)*
+*Defined in [near.ts:1463](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1463)*
 
 **Parameters:**
 
@@ -305,7 +305,7 @@ ___
 
 ▸ **storage_has_key**(key_len: *`usize`*, key_ptr: *`usize`*): `bool`
 
-*Defined in [near.ts:1400](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1400)*
+*Defined in [near.ts:1449](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1449)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **storage_iter**(prefix_len: *`usize`*, prefix_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1402](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1402)*
+*Defined in [near.ts:1451](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1451)*
 
 **Parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:1406](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1406)*
+*Defined in [near.ts:1455](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1455)*
 
 **Parameters:**
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **storage_range**(start_len: *`usize`*, start_ptr: *`usize`*, end_len: *`usize`*, end_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1404](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1404)*
+*Defined in [near.ts:1453](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1453)*
 
 **Parameters:**
 
@@ -378,7 +378,7 @@ ___
 
 ▸ **storage_remove**(key_len: *`usize`*, key_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1398](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1398)*
+*Defined in [near.ts:1447](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1447)*
 
 **Parameters:**
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **storage_write**(key_len: *`usize`*, key_ptr: *`usize`*, value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1396](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1396)*
+*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1445)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -32,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1193)*
+*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1193)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ ___
 
 ▸ **bytesToString**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1115)*
+*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1115)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1143)*
+*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1143)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1158)*
+*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1158)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1184)*
+*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1184)*
 
 **Parameters:**
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **parseFromBytes**<`T`>(bytes: *`Uint8Array`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1103)*
+*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1103)*
 
 Parses the given bytes array to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **parseFromString**<`T`>(s: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1075)*
+*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1075)*
 
 Parses the given string to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1180)*
+*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1180)*
 
 Returns random 32-bit integer.
 
@@ -188,7 +188,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1171)*
+*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1171)*
 
 Returns random byte buffer of given length.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1188)*
+*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1188)*
 
 **Type parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **stringToBytes**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1119)*
+*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1119)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -32,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1193)*
+*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1193)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ ___
 
 ▸ **bytesToString**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1115)*
+*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1115)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1143)*
+*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1143)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1158)*
+*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1158)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1184)*
+*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1184)*
 
 **Parameters:**
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **parseFromBytes**<`T`>(bytes: *`Uint8Array`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1103)*
+*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1103)*
 
 Parses the given bytes array to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **parseFromString**<`T`>(s: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1075)*
+*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1075)*
 
 Parses the given string to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1180)*
+*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1180)*
 
 Returns random 32-bit integer.
 
@@ -188,7 +188,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1171)*
+*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1171)*
 
 Returns random byte buffer of given length.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1188)*
+*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1188)*
 
 **Type parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **stringToBytes**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/cb5fe1e/near.ts#L1119)*
+*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1119)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -11,12 +11,16 @@
 ### Functions
 
 * [base58](_near_.near.md#base58)
+* [bytesToString](_near_.near.md#bytestostring)
 * [hash](_near_.near.md#hash)
 * [hash32](_near_.near.md#hash32)
 * [log](_near_.near.md#log)
+* [parseFromBytes](_near_.near.md#parsefrombytes)
+* [parseFromString](_near_.near.md#parsefromstring)
 * [random32](_near_.near.md#random32)
 * [randomBuffer](_near_.near.md#randombuffer)
 * [str](_near_.near.md#str)
+* [stringToBytes](_near_.near.md#stringtobytes)
 
 ---
 
@@ -28,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1133](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1133)*
+*Defined in [near.ts:1186](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1186)*
 
 **Parameters:**
 
@@ -39,13 +43,30 @@
 **Returns:** `string`
 
 ___
+<a id="bytestostring"></a>
+
+###  bytesToString
+
+▸ **bytesToString**(bytes: *`Uint8Array`*): `string`
+
+*Defined in [near.ts:1108](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1108)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| bytes | `Uint8Array` |
+
+**Returns:** `string`
+
+___
 <a id="hash"></a>
 
 ###  hash
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:1083](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1083)*
+*Defined in [near.ts:1136](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1136)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -67,7 +88,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:1098](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1098)*
+*Defined in [near.ts:1151](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1151)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -89,7 +110,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:1124](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1124)*
+*Defined in [near.ts:1177](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1177)*
 
 **Parameters:**
 
@@ -100,13 +121,61 @@ ___
 **Returns:** `void`
 
 ___
+<a id="parsefrombytes"></a>
+
+###  parseFromBytes
+
+▸ **parseFromBytes**<`T`>(bytes: *`Uint8Array`*, defaultValue?: *`T`*): `T`
+
+*Defined in [near.ts:1096](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1096)*
+
+Parses the given bytes array to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| bytes | `Uint8Array` | - |  Bytes to parse. |
+| `Default value` defaultValue | `T` |  null |  The default value if the bytes are null |
+
+**Returns:** `T`
+A parsed value of type T.
+
+___
+<a id="parsefromstring"></a>
+
+###  parseFromString
+
+▸ **parseFromString**<`T`>(s: *`string`*, defaultValue?: *`T`*): `T`
+
+*Defined in [near.ts:1068](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1068)*
+
+Parses the given string to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
+
+**Type parameters:**
+
+#### T 
+**Parameters:**
+
+| Name | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| s | `string` | - |  String to parse. |
+| `Default value` defaultValue | `T` |  null |  The default value if the string is null |
+
+**Returns:** `T`
+A parsed value of type T.
+
+___
 <a id="random32"></a>
 
 ###  random32
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:1120](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1120)*
+*Defined in [near.ts:1173](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1173)*
 
 Returns random 32-bit integer.
 
@@ -119,7 +188,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:1111](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1111)*
+*Defined in [near.ts:1164](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1164)*
 
 Returns random byte buffer of given length.
 
@@ -138,7 +207,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:1128](https://github.com/nearprotocol/near-runtime-ts/blob/a04d184/near.ts#L1128)*
+*Defined in [near.ts:1181](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1181)*
 
 **Type parameters:**
 
@@ -150,6 +219,23 @@ ___
 | value | `T` |
 
 **Returns:** `string`
+
+___
+<a id="stringtobytes"></a>
+
+###  stringToBytes
+
+▸ **stringToBytes**(s: *`string`*): `Uint8Array`
+
+*Defined in [near.ts:1112](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1112)*
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| s | `string` |
+
+**Returns:** `Uint8Array`
 
 ___
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -32,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1186](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1186)*
+*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1193)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ ___
 
 ▸ **bytesToString**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1108](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1108)*
+*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1115)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:1136](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1136)*
+*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1143)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:1151](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1151)*
+*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1158)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:1177](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1177)*
+*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1184)*
 
 **Parameters:**
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **parseFromBytes**<`T`>(bytes: *`Uint8Array`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1096](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1096)*
+*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1103)*
 
 Parses the given bytes array to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **parseFromString**<`T`>(s: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1068](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1068)*
+*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1075)*
 
 Parses the given string to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:1173](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1173)*
+*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1180)*
 
 Returns random 32-bit integer.
 
@@ -188,7 +188,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:1164](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1164)*
+*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1171)*
 
 Returns random byte buffer of given length.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:1181](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1181)*
+*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1188)*
 
 **Type parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **stringToBytes**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1112](https://github.com/nearprotocol/near-runtime-ts/blob/16a2965/near.ts#L1112)*
+*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/60838e5/near.ts#L1119)*
 
 **Parameters:**
 

--- a/near.ts
+++ b/near.ts
@@ -1046,7 +1046,7 @@ class Context {
    * If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible.
    * Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
    */
-  get deposit(min_amount: u64, max_amount: u64): u64 {
+  deposit(min_amount: u64, max_amount: u64): u64 {
     deposit(min_amount, max_amount)
   }
 
@@ -1055,7 +1055,7 @@ class Context {
    * If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible.
    * Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
    */
-  get withdraw(min_amount: u64, max_amount: u64): u64 {
+  withdraw(min_amount: u64, max_amount: u64): u64 {
     withdraw(min_amount, max_amount)
   }
 }

--- a/near.ts
+++ b/near.ts
@@ -1035,6 +1035,13 @@ class Context {
   }
 
   /**
+   * The current storage usage in bytes.
+   */
+  get storageUsage(): u64 {
+    return storage_usage();
+  }
+
+  /**
    * Moves assets from liquid balance to frozen balance.
    * If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible.
    * Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
@@ -1527,6 +1534,12 @@ declare function frozen_balance(): u64;
  */
 @external("env", "liquid_balance")
 declare function liquid_balance(): u64;
+
+/**
+ * @hidden
+ */
+@external("env", "storage_usage")
+declare function storage_usage(): u64;
 
 /**
  * @hidden

--- a/near.ts
+++ b/near.ts
@@ -1013,13 +1013,6 @@ class Context {
   }
 
   /**
-   * Current balance of the contract.
-   */
-  get currentBalance(): u64 {
-    return balance();
-  }
-
-  /**
    * The amount of tokens received with this execution call.
    */
   get receivedAmount(): u64 {
@@ -1027,17 +1020,36 @@ class Context {
   }
 
   /**
-   * The amount of available gas left for this execution call.
+   * The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
    */
-  get gasLeft(): u64 {
-    return gas_left();
+  get frozenBalance(): u64 {
+    return frozen_balance();
   }
 
   /**
-   * The amount of available mana left for this execution call.
+   * The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts
+   * through cross-contract calls.
    */
-  get manaLeft(): u32 {
-    return mana_left();
+  get liquidBalance(): u64 {
+      return liquid_balance();
+  }
+
+  /**
+   * Moves assets from liquid balance to frozen balance.
+   * If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible.
+   * Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
+   */
+  get deposit(min_amount: u64, max_amount: u64): u64 {
+    deposit(min_amount, max_amount)
+  }
+
+   /**
+   * Moves assets from frozen balance to liquid balance.
+   * If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible.
+   * Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
+   */
+  get withdraw(min_amount: u64, max_amount: u64): u64 {
+    withdraw(min_amount, max_amount)
   }
 }
 
@@ -1239,7 +1251,6 @@ export namespace near {
  *     "addItem",
  *     itemArgs.encode(),
  *     0,
- *     0,
  *   );
  *   // Setting up args for the callback
  *   let requestArgs: OnItemAddedArgs = {
@@ -1276,14 +1287,12 @@ export class ContractPromise {
    *     // Serialize args
    *     let args = itemArgs.encode();
    *     ```
-   * @param mana The amount of additional requests the remote contract would be able to do.
    * @param amount The amount of tokens from your contract to be sent to the remote contract with this call.
    */
   static create(
       contractName: string,
       methodName: string,
       args: Uint8Array,
-      mana: u32,
       amount: u64 = 0
   ): ContractPromise {
     return {
@@ -1291,7 +1300,6 @@ export class ContractPromise {
         contractName.lengthUTF8 - 1, contractName.toUTF8(),
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
         args.byteLength, args.buffer.data,
-        mana,
         amount)
     };
   }
@@ -1302,19 +1310,19 @@ export class ContractPromise {
    *     NOTE: Your callback method name can start with `_`, which would prevent other
    *     contracts from calling it directly. Only callbacks can call methods with `_` prefix.
    * @param args Serialized arguments on your callback method, see `create` for details.
-   * @param mana The amount of additional requests your contract would be able to do.
+   * @param amount The amount of tokens from the called contract to be sent to the current contract with this call.
    */
   then(
       methodName: string,
       args: Uint8Array,
-      mana: u32
+      amount: u64
   ): ContractPromise {
     return {
       id: promise_then(
         this.id,
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
         args.byteLength, args.buffer.data,
-        mana)
+        amount)
     };
   }
 
@@ -1464,7 +1472,6 @@ declare function promise_create(
     account_id_len: usize, account_id_ptr: usize,
     method_name_len: usize, method_name_ptr: usize,
     args_len: usize, args_ptr: usize,
-    mana: u32,
     amount: u64): u32;
 
 @external("env", "promise_then")
@@ -1472,7 +1479,7 @@ declare function promise_then(
     promise_index: u32,
     method_name_len: usize, method_name_ptr: usize,
     args_len: usize, args_ptr: usize,
-    mana: u32): u32;
+    amount: u64): u32;
 
 @external("env", "promise_and")
 declare function promise_and(promise_index1: u32, promise_index2: u32): u32;
@@ -1512,20 +1519,26 @@ declare function _near_log(msg_ptr: usize): void;
 /**
  * @hidden
  */
-@external("env", "balance")
-declare function balance(): u64;
+@external("env", "frozen_balance")
+declare function frozen_balance(): u64;
 
 /**
  * @hidden
  */
-@external("env", "mana_left")
-declare function mana_left(): u32;
+@external("env", "liquid_balance")
+declare function liquid_balance(): u64;
 
 /**
  * @hidden
  */
-@external("env", "gas_left")
-declare function gas_left(): u64;
+@external("env", "deposit")
+declare function deposit(min_amount: u64, max_amount: u64): u64;
+
+/**
+ * @hidden
+ */
+@external("env", "withdraw")
+declare function withdraw(min_amount: u64, max_amount: u64): u64;
 
 /**
  * @hidden

--- a/near.ts
+++ b/near.ts
@@ -1046,8 +1046,8 @@ class Context {
    * If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible.
    * Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
    */
-  deposit(min_amount: u64, max_amount: u64): u64 {
-    deposit(min_amount, max_amount)
+  deposit(minAmount: u64, maxAmount: u64): u64 {
+    deposit(minAmount, maxAmount)
   }
 
    /**
@@ -1055,8 +1055,8 @@ class Context {
    * If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible.
    * Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
    */
-  withdraw(min_amount: u64, max_amount: u64): u64 {
-    withdraw(min_amount, max_amount)
+  withdraw(minAmount: u64, maxAmount: u64): u64 {
+    withdraw(minAmount, maxAmount)
   }
 }
 


### PR DESCRIPTION
3 part change:
https://github.com/nearprotocol/nearcore/pull/952
https://github.com/nearprotocol/near-runtime-ts/pull/20
https://github.com/nearprotocol/nearlib/pull/14

See the roadmap for Economics Implementation and the list of changes in these 3 PRs here:
https://docs.google.com/document/d/1rydPgSHwPaKQLL57Xogsw8tgjTPKG98cK3kgK_PnjCQ/edit#
