### PR TITLE
Fix a bug in bytesToString

### DIFF
--- a/assembly/__tests__/near.spec.ts
+++ b/assembly/__tests__/near.spec.ts
@@ -8,6 +8,19 @@ function testBase64(original: string, expectedEncoding: string): void {
     expect<string>(near.bytesToString(decoded)).toBe(original);
 }
 
+describe('utils', (): void => {
+    it('bytesToString', (): void => {
+        let byteArray = new Uint8Array(4);
+        byteArray[0] = 131;
+        byteArray[1] = 100;
+        byteArray[2] = 111;
+        byteArray[3] = 103;
+        let bytes = byteArray.subarray(1);
+        let s = near.bytesToString(bytes);
+        expect<string>(s).toBe('dog');
+    });
+});
+
 describe('base64 encoding/decoding', (): void => {
     it('hello world', (): void => {
         testBase64('hello, world', 'aGVsbG8sIHdvcmxk');

--- a/near.ts
+++ b/near.ts
@@ -1094,7 +1094,7 @@ export namespace near {
   }
 
   export function bytesToString(bytes: Uint8Array): string {
-    return String.fromUTF8(bytes.buffer.data, bytes.byteLength)
+    return String.fromUTF8(bytes.buffer.data + bytes.byteOffset, bytes.byteLength)
   }
 
   export function stringToBytes(s: string): Uint8Array {


### PR DESCRIPTION
`bytesToString` in `near.ts` has a bug that will result in incorrect behavior when dealing with `Uint8Array` produced by the `subarray` method on `Uint8Array`. For more details, see https://github.com/AssemblyScript/assemblyscript/issues/593.