### PR TITLE
NightShade update

### DIFF
--- a/apidoc/README.md
+++ b/apidoc/README.md
@@ -4,24 +4,27 @@ near-runtime-ts
 
 Typescript library for writing near smart contracts
 
-\## Documentation
+Generate documentation
+----------------------
 
-API docs are produced using typedoc. To run, first install typedoc
-
-```
-npm install --save-dev typedoc
-npm install --save-dev typedoc typedoc-plugin-markdown
-```
-
-After installing typedoc, run
+API docs are produced using typedoc. To run, first install dependencies:
 
 ```
-rm -rf apidoc
-mkdir apidoc
-node_modules/.bin/typedoc near.ts --theme markdown --ignoreCompilerErrors --excludePrivate --excludeProtected --excludeExternals --out apidoc/
+npm install
 ```
 
-(The tool does not deal well with items being removed from documentation, hence the need to delete output)
+After installing dependencies, run
+
+```
+npm run doc
+```
+
+Run tests
+---------
+
+```
+npm test
+```
 
 ## Index
 

--- a/apidoc/classes/_near_.collections.deque.md
+++ b/apidoc/classes/_near_.collections.deque.md
@@ -44,7 +44,7 @@ A deque class that implements a persistent bidirectional queue.
 
 ⊕ **new Deque**(prefix: *`string`*): [Deque](_near_.collections.deque.md)
 
-*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L457)*
+*Defined in [near.ts:457](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L457)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -64,9 +64,9 @@ ___
 
 ###  back
 
-**get back**(): `T`
+getback(): `T`
 
-*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L659)*
+*Defined in [near.ts:659](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L659)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -76,9 +76,9 @@ ___
 
 ###  first
 
-**get first**(): `T`
+getfirst(): `T`
 
-*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L626)*
+*Defined in [near.ts:626](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L626)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -88,9 +88,9 @@ ___
 
 ###  front
 
-**get front**(): `T`
+getfront(): `T`
 
-*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L618)*
+*Defined in [near.ts:618](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L618)*
 
 **Returns:** `T`
 The first/front element of the deque.
@@ -100,9 +100,9 @@ ___
 
 ###  isEmpty
 
-**get isEmpty**(): `bool`
+getisEmpty(): `bool`
 
-*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L543)*
+*Defined in [near.ts:543](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L543)*
 
 **Returns:** `bool`
 True if the deque is empty.
@@ -112,9 +112,9 @@ ___
 
 ###  last
 
-**get last**(): `T`
+getlast(): `T`
 
-*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L667)*
+*Defined in [near.ts:667](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L667)*
 
 **Returns:** `T`
 The last/back element of the deque.
@@ -124,9 +124,9 @@ ___
 
 ###  length
 
-**get length**(): `i32`
+getlength(): `i32`
 
-*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L536)*
+*Defined in [near.ts:536](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L536)*
 
 **Returns:** `i32`
 The length of the deque.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L520)*
+*Defined in [near.ts:520](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L520)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L528)*
+*Defined in [near.ts:528](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L528)*
 
 Removes the content of the element from storage without changing length of the deque.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L647)*
+*Defined in [near.ts:647](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L647)*
 
 Removes the last/back element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popFront**(): `T`
 
-*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L607)*
+*Defined in [near.ts:607](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L607)*
 
 Removes the first/front element from the deque and returns it. Asserts that the deque is not empty. Decreases the length of the deque.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L635)*
+*Defined in [near.ts:635](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L635)*
 
 Adds a new element to the end of the deque. Increases the length of the deque.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushFront**(element: *`T`*): `i32`
 
-*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L596)*
+*Defined in [near.ts:596](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L596)*
 
 Adds a new element in front of the deque. Increases the length of the deque.
 

--- a/apidoc/classes/_near_.collections.map.md
+++ b/apidoc/classes/_near_.collections.map.md
@@ -35,7 +35,7 @@ A map class that implements a persistent unordered map. NOTE: The Map doesn't st
 
 ⊕ **new Map**(prefix: *`string`*): [Map](_near_.collections.map.md)
 
-*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L678)*
+*Defined in [near.ts:678](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L678)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -57,7 +57,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L718)*
+*Defined in [near.ts:718](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L718)*
 
 **Parameters:**
 
@@ -75,7 +75,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L726)*
+*Defined in [near.ts:726](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L726)*
 
 Removes value and the key from the map.
 
@@ -94,7 +94,7 @@ ___
 
 ▸ **get**(key: *`K`*, defaultValue?: *`V`*): `V`
 
-*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L735)*
+*Defined in [near.ts:735](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L735)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **set**(key: *`K`*, value: *`V`*): `void`
 
-*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L744)*
+*Defined in [near.ts:744](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L744)*
 
 Sets the new value for the given key.
 
@@ -133,7 +133,7 @@ ___
 
 ▸ **values**(start?: *`K`*, end?: *`K`*, limit?: *`i32`*, startInclusive?: *`bool`*): `V`[]
 
-*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L704)*
+*Defined in [near.ts:704](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L704)*
 
 Returns values of the map between the given start key and the end key.
 

--- a/apidoc/classes/_near_.collections.topn.md
+++ b/apidoc/classes/_near_.collections.topn.md
@@ -44,7 +44,7 @@ A TopN class that can return first N keys of a type K sorted by rating. Rating i
 
 ⊕ **new TopN**(prefix: *`string`*, descending?: *`bool`*): [TopN](_near_.collections.topn.md)
 
-*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L764)*
+*Defined in [near.ts:764](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L764)*
 
 Creates or restores a persistent top N collection with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -65,9 +65,9 @@ ___
 
 ###  isEmpty
 
-**get isEmpty**(): `bool`
+getisEmpty(): `bool`
 
-*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L808)*
+*Defined in [near.ts:808](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L808)*
 
 **Returns:** `bool`
 True if the TopN collection is empty.
@@ -77,9 +77,9 @@ ___
 
 ###  length
 
-**get length**(): `i32`
+getlength(): `i32`
 
-*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L815)*
+*Defined in [near.ts:815](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L815)*
 
 **Returns:** `i32`
 The number of unique elements in the TopN collection.
@@ -94,7 +94,7 @@ ___
 
 ▸ **contains**(key: *`K`*): `bool`
 
-*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L835)*
+*Defined in [near.ts:835](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L835)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ ___
 
 ▸ **delete**(key: *`K`*): `void`
 
-*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L843)*
+*Defined in [near.ts:843](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L843)*
 
 Removes rating and the key from the collection.
 
@@ -131,7 +131,7 @@ ___
 
 ▸ **getRating**(key: *`K`*, defaultRating?: *`i32`*): `i32`
 
-*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L913)*
+*Defined in [near.ts:913](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L913)*
 
 **Parameters:**
 
@@ -150,7 +150,7 @@ ___
 
 ▸ **getTop**(limit: *`i32`*): `K`[]
 
-*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L869)*
+*Defined in [near.ts:869](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L869)*
 
 **Parameters:**
 
@@ -168,7 +168,7 @@ ___
 
 ▸ **getTopFromKey**(limit: *`i32`*, fromKey: *`K`*): `K`[]
 
-*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L880)*
+*Defined in [near.ts:880](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L880)*
 
 Returns a top list starting from the given key (exclusive). It's useful for pagination.
 
@@ -189,7 +189,7 @@ ___
 
 ▸ **getTopWithRating**(limit: *`i32`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L893)*
+*Defined in [near.ts:893](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L893)*
 
 **Parameters:**
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **getTopWithRatingFromKey**(limit: *`i32`*, fromKey: *`K`*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L904)*
+*Defined in [near.ts:904](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L904)*
 
 Returns a top list with rating starting from the given key (exclusive). It's useful for pagination.
 
@@ -228,7 +228,7 @@ ___
 
 ▸ **incrementRating**(key: *`K`*, increment?: *`i32`*): `void`
 
-*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L938)*
+*Defined in [near.ts:938](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L938)*
 
 Increments rating of the given key by the given increment (1 by default).
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **keysToRatings**(keys: *`K`[]*): [MapEntry](_near_.near.mapentry.md)<`K`, `i32`>[]
 
-*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L856)*
+*Defined in [near.ts:856](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L856)*
 
 **Parameters:**
 
@@ -266,7 +266,7 @@ ___
 
 ▸ **setRating**(key: *`K`*, rating: *`i32`*): `void`
 
-*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L922)*
+*Defined in [near.ts:922](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L922)*
 
 Sets the new rating for the given key.
 

--- a/apidoc/classes/_near_.collections.vector.md
+++ b/apidoc/classes/_near_.collections.vector.md
@@ -44,7 +44,7 @@ A vector class that implements a persistent array.
 
 ⊕ **new Vector**(prefix: *`string`*): [Vector](_near_.collections.vector.md)
 
-*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L264)*
+*Defined in [near.ts:264](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L264)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -64,9 +64,9 @@ ___
 
 ###  back
 
-**get back**(): `T`
+getback(): `T`
 
-*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L420)*
+*Defined in [near.ts:420](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L420)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -76,9 +76,9 @@ ___
 
 ###  first
 
-**get first**(): `T`
+getfirst(): `T`
 
-*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L443)*
+*Defined in [near.ts:443](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L443)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -88,9 +88,9 @@ ___
 
 ###  front
 
-**get front**(): `T`
+getfront(): `T`
 
-*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L435)*
+*Defined in [near.ts:435](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L435)*
 
 **Returns:** `T`
 The first element of the vector. Asserts that the vector is not empty.
@@ -100,9 +100,9 @@ ___
 
 ###  isEmpty
 
-**get isEmpty**(): `bool`
+getisEmpty(): `bool`
 
-*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L305)*
+*Defined in [near.ts:305](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L305)*
 
 **Returns:** `bool`
 True if the vector is empty.
@@ -112,9 +112,9 @@ ___
 
 ###  last
 
-**get last**(): `T`
+getlast(): `T`
 
-*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L428)*
+*Defined in [near.ts:428](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L428)*
 
 **Returns:** `T`
 The last element of the vector. Asserts that the vector is not empty.
@@ -124,9 +124,9 @@ ___
 
 ###  length
 
-**get length**(): `i32`
+getlength(): `i32`
 
-*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L312)*
+*Defined in [near.ts:312](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L312)*
 
 **Returns:** `i32`
 The length of the vector.
@@ -141,7 +141,7 @@ ___
 
 ▸ **containsIndex**(index: *`i32`*): `bool`
 
-*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L298)*
+*Defined in [near.ts:298](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L298)*
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ ___
 
 ▸ **delete**(index: *`i32`*): `void`
 
-*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L289)*
+*Defined in [near.ts:289](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L289)*
 
 Removes the content of the element from storage without changing length of the vector.
 
@@ -178,7 +178,7 @@ ___
 
 ▸ **pop**(): `T`
 
-*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L398)*
+*Defined in [near.ts:398](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L398)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -192,7 +192,7 @@ ___
 
 ▸ **popBack**(): `T`
 
-*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L413)*
+*Defined in [near.ts:413](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L413)*
 
 Removes the last element from the vector and returns it. Asserts that the vector is not empty. Decreases the length of the vector.
 
@@ -206,7 +206,7 @@ ___
 
 ▸ **push**(element: *`T`*): `i32`
 
-*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L376)*
+*Defined in [near.ts:376](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L376)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 
@@ -226,7 +226,7 @@ ___
 
 ▸ **pushBack**(element: *`T`*): `i32`
 
-*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L389)*
+*Defined in [near.ts:389](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L389)*
 
 Adds a new element to the end of the vector. Increases the length of the vector.
 

--- a/apidoc/classes/_near_.context.md
+++ b/apidoc/classes/_near_.context.md
@@ -33,9 +33,9 @@ Provides context for contract execution, including information about transaction
 
 ###  blockIndex
 
-**get blockIndex**(): `u64`
+getblockIndex(): `u64`
 
-*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1011)*
+*Defined in [near.ts:1011](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1011)*
 
 Current block index.
 
@@ -46,9 +46,9 @@ ___
 
 ###  contractName
 
-**get contractName**(): `string`
+getcontractName(): `string`
 
-*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1004)*
+*Defined in [near.ts:1004](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1004)*
 
 Account ID of contract.
 
@@ -59,9 +59,9 @@ ___
 
 ###  frozenBalance
 
-**get frozenBalance**(): `u64`
+getfrozenBalance(): `u64`
 
-*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1025)*
+*Defined in [near.ts:1025](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1025)*
 
 The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
 
@@ -72,9 +72,9 @@ ___
 
 ###  liquidBalance
 
-**get liquidBalance**(): `u64`
+getliquidBalance(): `u64`
 
-*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1033)*
+*Defined in [near.ts:1033](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1033)*
 
 The amount of tokens that can be used for running wasm, creating transactions, and sending to other contracts through cross-contract calls.
 
@@ -85,9 +85,9 @@ ___
 
 ###  receivedAmount
 
-**get receivedAmount**(): `u64`
+getreceivedAmount(): `u64`
 
-*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1018)*
+*Defined in [near.ts:1018](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1018)*
 
 The amount of tokens received with this execution call.
 
@@ -98,9 +98,9 @@ ___
 
 ###  sender
 
-**get sender**(): `string`
+getsender(): `string`
 
-*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L997)*
+*Defined in [near.ts:997](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L997)*
 
 Account ID of transaction sender.
 
@@ -111,9 +111,9 @@ ___
 
 ###  storageUsage
 
-**get storageUsage**(): `u64`
+getstorageUsage(): `u64`
 
-*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1040)*
+*Defined in [near.ts:1040](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1040)*
 
 The current storage usage in bytes.
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **deposit**(minAmount: *`u64`*, maxAmount: *`u64`*): `u64`
 
-*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1049)*
+*Defined in [near.ts:1049](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1049)*
 
 Moves assets from liquid balance to frozen balance. If there is enough liquid balance will deposit the maximum amount. Otherwise will deposit as much as possible. Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **withdraw**(minAmount: *`u64`*, maxAmount: *`u64`*): `u64`
 
-*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1058)*
+*Defined in [near.ts:1058](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1058)*
 
 Moves assets from frozen balance to liquid balance. If there is enough frozen balance will withdraw the maximum amount. Otherwise will withdraw as much as possible. Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
 

--- a/apidoc/classes/_near_.contractpromise.md
+++ b/apidoc/classes/_near_.contractpromise.md
@@ -59,7 +59,7 @@ See docs on used methods for more details.
 
 **● id**: *`i32`*
 
-*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1278)*
+*Defined in [near.ts:1278](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1278)*
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 ▸ **returnAsResult**(): `void`
 
-*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1382)*
+*Defined in [near.ts:1382](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1382)*
 
 Returns the promise as a result of your function. Don't return any other results from the function. Your current function should be `void` and shouldn't return anything else. E.g.
 
@@ -123,7 +123,7 @@ ___
 
 ▸ **then**(methodName: *`string`*, args: *`Uint8Array`*, amount: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1322)*
+*Defined in [near.ts:1322](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1322)*
 
 Creating a callback for the AsyncCall Promise created with `create` method.
 
@@ -144,7 +144,7 @@ ___
 
 ▸ **all**(promises: *[ContractPromise](_near_.contractpromise.md)[]*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1392)*
+*Defined in [near.ts:1392](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1392)*
 
 Joins multiple async call promises into one, to aggregate results before the callback. NOTE: Given promises can only be new async calls and can't be callbacks. Joined promise can't be returned as a result
 
@@ -163,7 +163,7 @@ ___
 
 ▸ **create**(contractName: *`string`*, methodName: *`string`*, args: *`Uint8Array`*, amount?: *`u64`*): [ContractPromise](_near_.contractpromise.md)
 
-*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1299)*
+*Defined in [near.ts:1299](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1299)*
 
 Creates a new async call promise. Returns an instance of `ContractPromise`. The call would be scheduled if the this current execution of the contract succeeds without errors or failed asserts.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getResults**(): [ContractPromiseResult](_near_.contractpromiseresult.md)[]
 
-*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1424)*
+*Defined in [near.ts:1424](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1424)*
 
 Method to receive async (one or multiple) results from the remote contract in the callback. Example of using it.
 

--- a/apidoc/classes/_near_.contractpromiseresult.md
+++ b/apidoc/classes/_near_.contractpromiseresult.md
@@ -25,7 +25,7 @@ Class to store results of the async calls on the remote contracts.
 
 **● buffer**: *`Uint8Array`*
 
-*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1448)*
+*Defined in [near.ts:1448](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1448)*
 
 ___
 <a id="success"></a>
@@ -34,7 +34,7 @@ ___
 
 **● success**: *`bool`*
 
-*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1445)*
+*Defined in [near.ts:1445](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1445)*
 
 ___
 

--- a/apidoc/classes/_near_.near.mapentry.md
+++ b/apidoc/classes/_near_.near.mapentry.md
@@ -32,7 +32,7 @@ Helper class to store key->value pairs.
 
 ⊕ **new MapEntry**(key: *`K`*, value: *`V`*): [MapEntry](_near_.near.mapentry.md)
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1131)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ ___
 
 **● key**: *`K`*
 
-*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1130)*
+*Defined in [near.ts:1130](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1130)*
 
 ___
 <a id="value"></a>
@@ -62,7 +62,7 @@ ___
 
 **● value**: *`V`*
 
-*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1131)*
+*Defined in [near.ts:1131](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1131)*
 
 ___
 

--- a/apidoc/classes/_near_.storage.md
+++ b/apidoc/classes/_near_.storage.md
@@ -40,7 +40,7 @@ Represents contract storage.
 
 ▸ **contains**(key: *`string`*): `bool`
 
-*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L113)*
+*Defined in [near.ts:113](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L113)*
 
 Returns true if the given key is present in the storage.
 
@@ -59,7 +59,7 @@ ___
 
 ▸ **delete**(key: *`string`*): `void`
 
-*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L122)*
+*Defined in [near.ts:122](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L122)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ ___
 
 ▸ **get**<`T`>(key: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L185)*
+*Defined in [near.ts:185](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L185)*
 
 Gets given generic value stored under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -100,7 +100,7 @@ ___
 
 ▸ **getBytes**(key: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L106)*
+*Defined in [near.ts:106](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L106)*
 
 Get byte array stored under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -121,9 +121,10 @@ ___
 
 ▸ **getItem**(key: *`string`*): `string`
 
-*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L72)*
+*Defined in [near.ts:72](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L72)*
 
-*__deprecated__*: Use getString or get
+*__deprecated__*:
+ Use getString or get
 
 **Parameters:**
 
@@ -140,7 +141,7 @@ ___
 
 ▸ **getString**(key: *`string`*): `string`
 
-*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L86)*
+*Defined in [near.ts:86](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L86)*
 
 Get string value stored under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -159,7 +160,7 @@ ___
 
 ▸ **getU64**(key: *`string`*): `u64`
 
-*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L156)*
+*Defined in [near.ts:156](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L156)*
 
 Get 64-bit unsigned int stored under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 
@@ -179,7 +180,7 @@ ___
 
 ▸ **hasKey**(key: *`string`*): `bool`
 
-*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L118)*
+*Defined in [near.ts:118](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L118)*
 
 **Parameters:**
 
@@ -196,7 +197,7 @@ ___
 
 ▸ **keyRange**(start: *`string`*, end: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L42)*
+*Defined in [near.ts:42](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L42)*
 
 Returns list of keys between the given start key and the end key. Both inclusive. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -217,7 +218,7 @@ ___
 
 ▸ **keys**(prefix: *`string`*, limit?: *`i32`*): `string`[]
 
-*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L55)*
+*Defined in [near.ts:55](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L55)*
 
 Returns list of keys starting with given prefix. NOTE: Must be very careful to avoid exploding amount of compute with this method.
 
@@ -237,9 +238,10 @@ ___
 
 ▸ **remove**(key: *`string`*): `void`
 
-*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L130)*
+*Defined in [near.ts:130](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L130)*
 
-*__deprecated__*: Use #delete
+*__deprecated__*:
+ Use #delete
 
 **Parameters:**
 
@@ -256,9 +258,10 @@ ___
 
 ▸ **removeItem**(key: *`string`*): `void`
 
-*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L138)*
+*Defined in [near.ts:138](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L138)*
 
-*__deprecated__*: Use #delete
+*__deprecated__*:
+ Use #delete
 
 **Parameters:**
 
@@ -275,7 +278,7 @@ ___
 
 ▸ **set**<`T`>(key: *`string`*, value: *`T`*): `void`
 
-*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L167)*
+*Defined in [near.ts:167](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L167)*
 
 Stores given generic value under the key. Key is encoded as UTF-8 strings. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -298,7 +301,7 @@ ___
 
 ▸ **setBytes**(key: *`string`*, value: *`Uint8Array`*): `void`
 
-*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L96)*
+*Defined in [near.ts:96](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L96)*
 
 Store byte array under given key. Key is encoded as UTF-8 strings. Byte array stored as is.
 
@@ -320,9 +323,10 @@ ___
 
 ▸ **setItem**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L65)*
+*Defined in [near.ts:65](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L65)*
 
-*__deprecated__*: Use setString or set
+*__deprecated__*:
+ Use setString or set
 
 **Parameters:**
 
@@ -340,7 +344,7 @@ ___
 
 ▸ **setString**(key: *`string`*, value: *`string`*): `void`
 
-*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L79)*
+*Defined in [near.ts:79](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L79)*
 
 Store string value under given key. Both key and value are encoded as UTF-8 strings.
 
@@ -360,7 +364,7 @@ ___
 
 ▸ **setU64**(key: *`string`*, value: *`u64`*): `void`
 
-*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L146)*
+*Defined in [near.ts:146](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L146)*
 
 Store 64-bit unsigned int under given key. Key is encoded as UTF-8 strings. Number is encoded as decimal string.
 

--- a/apidoc/modules/_near_.base64.md
+++ b/apidoc/modules/_near_.base64.md
@@ -27,7 +27,7 @@ base64 encoding/decoding
 
 **● ALPHA**: *`string`* = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1574)*
+*Defined in [near.ts:1574](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1574)*
 
 ___
 <a id="padchar"></a>
@@ -36,7 +36,7 @@ ___
 
 **● PADCHAR**: *`string`* = "="
 
-*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1573)*
+*Defined in [near.ts:1573](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1573)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 ▸ **decode**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1584)*
+*Defined in [near.ts:1584](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1584)*
 
 Decode base64-encoded string and return a Uint8Array.
 
@@ -67,7 +67,7 @@ ___
 
 ▸ **encode**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1633)*
+*Defined in [near.ts:1633](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1633)*
 
 Encode Uint8Array in base64.
 
@@ -86,7 +86,7 @@ ___
 
 ▸ **getByte64**(s: *`string`*, i: *`u32`*): `u32`
 
-*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1576)*
+*Defined in [near.ts:1576](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1576)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.collections.md
+++ b/apidoc/modules/_near_.collections.md
@@ -39,7 +39,7 @@ A namespace with classes and functions for persistent collections on the blockch
 
 **● _KEY_BACK_INDEX_SUFFIX**: *":back"* = ":back"
 
-*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L253)*
+*Defined in [near.ts:253](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L253)*
 
 ___
 <a id="_key_element_suffix"></a>
@@ -48,7 +48,7 @@ ___
 
 **● _KEY_ELEMENT_SUFFIX**: *"::"* = "::"
 
-*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L254)*
+*Defined in [near.ts:254](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L254)*
 
 ___
 <a id="_key_front_index_suffix"></a>
@@ -57,7 +57,7 @@ ___
 
 **● _KEY_FRONT_INDEX_SUFFIX**: *":front"* = ":front"
 
-*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L252)*
+*Defined in [near.ts:252](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L252)*
 
 ___
 <a id="_key_length_suffix"></a>
@@ -66,7 +66,7 @@ ___
 
 **● _KEY_LENGTH_SUFFIX**: *":len"* = ":len"
 
-*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L251)*
+*Defined in [near.ts:251](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L251)*
 
 ___
 <a id="_key_rating_suffix"></a>
@@ -75,7 +75,7 @@ ___
 
 **● _KEY_RATING_SUFFIX**: *":r"* = ":r"
 
-*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L255)*
+*Defined in [near.ts:255](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L255)*
 
 ___
 <a id="_rating_offset"></a>
@@ -84,7 +84,7 @@ ___
 
 **● _RATING_OFFSET**: *`u64`* = 2147483648
 
-*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L256)*
+*Defined in [near.ts:256](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L256)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 ▸ **deque**<`T`>(prefix: *`string`*): [Deque](../classes/_near_.collections.deque.md)<`T`>
 
-*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L966)*
+*Defined in [near.ts:966](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L966)*
 
 Creates or restores a persistent deque with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -118,7 +118,7 @@ ___
 
 ▸ **map**<`K`,`V`>(prefix: *`string`*): [Map](../classes/_near_.collections.map.md)<`K`, `V`>
 
-*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L975)*
+*Defined in [near.ts:975](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L975)*
 
 Creates or restores a persistent map with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -141,7 +141,7 @@ ___
 
 ▸ **topN**<`K`>(prefix: *`string`*, descending?: *`bool`*): [TopN](../classes/_near_.collections.topn.md)<`K`>
 
-*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L985)*
+*Defined in [near.ts:985](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L985)*
 
 Creates or restores a persistent TopN with a given storage prefix. Always use a unique storage prefix for different collections.
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **vector**<`T`>(prefix: *`string`*): [Vector](../classes/_near_.collections.vector.md)<`T`>
 
-*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L957)*
+*Defined in [near.ts:957](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L957)*
 
 Creates or restores a persistent vector with a given storage prefix. Always use a unique storage prefix for different collections.
 

--- a/apidoc/modules/_near_.md
+++ b/apidoc/modules/_near_.md
@@ -60,7 +60,7 @@
 
 **Ƭ DataTypeIndex**: *`u32`*
 
-*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L3)*
+*Defined in [near.ts:3](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L3)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 **● DATA_TYPE_CURRENT_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 2
 
-*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L6)*
+*Defined in [near.ts:6](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L6)*
 
 ___
 <a id="data_type_input"></a>
@@ -81,7 +81,7 @@ ___
 
 **● DATA_TYPE_INPUT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 4
 
-*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L8)*
+*Defined in [near.ts:8](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L8)*
 
 ___
 <a id="data_type_originator_account_id"></a>
@@ -90,7 +90,7 @@ ___
 
 **● DATA_TYPE_ORIGINATOR_ACCOUNT_ID**: *[DataTypeIndex](_near_.md#datatypeindex)* = 1
 
-*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L5)*
+*Defined in [near.ts:5](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L5)*
 
 ___
 <a id="data_type_result"></a>
@@ -99,7 +99,7 @@ ___
 
 **● DATA_TYPE_RESULT**: *[DataTypeIndex](_near_.md#datatypeindex)* = 5
 
-*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L9)*
+*Defined in [near.ts:9](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L9)*
 
 ___
 <a id="data_type_storage"></a>
@@ -108,7 +108,7 @@ ___
 
 **● DATA_TYPE_STORAGE**: *[DataTypeIndex](_near_.md#datatypeindex)* = 3
 
-*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L7)*
+*Defined in [near.ts:7](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L7)*
 
 ___
 <a id="data_type_storage_iter"></a>
@@ -117,7 +117,7 @@ ___
 
 **● DATA_TYPE_STORAGE_ITER**: *[DataTypeIndex](_near_.md#datatypeindex)* = 6
 
-*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L10)*
+*Defined in [near.ts:10](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L10)*
 
 ___
 <a id="default_scratch_buffer_size"></a>
@@ -126,7 +126,7 @@ ___
 
 **● DEFAULT_SCRATCH_BUFFER_SIZE**: *`usize`* =  1 << 16
 
-*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1)*
+*Defined in [near.ts:1](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1)*
 
 ___
 <a id="context-1"></a>
@@ -135,7 +135,7 @@ ___
 
 **● context**: *[Context](../classes/_near_.context.md)* =  new Context()
 
-*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1063)*
+*Defined in [near.ts:1063](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1063)*
 
 ___
 <a id="storage-1"></a>
@@ -144,7 +144,7 @@ ___
 
 **● storage**: *[Storage](../classes/_near_.storage.md)* =  new Storage()
 
-*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L245)*
+*Defined in [near.ts:245](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L245)*
 
 An instance of a Storage class that is used for working with contract storage on the blockchain.
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **data_read**(type_index: *`u32`*, key_len: *`usize`*, key: *`usize`*, max_buf_len: *`usize`*, buf_ptr: *`usize`*): `usize`
 
-*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1475)*
+*Defined in [near.ts:1475](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1475)*
 
 **Parameters:**
 
@@ -179,7 +179,7 @@ ___
 
 ▸ **promise_and**(promise_index1: *`u32`*, promise_index2: *`u32`*): `u32`
 
-*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1492)*
+*Defined in [near.ts:1492](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1492)*
 
 **Parameters:**
 
@@ -197,7 +197,7 @@ ___
 
 ▸ **promise_create**(account_id_len: *`usize`*, account_id_ptr: *`usize`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1478)*
+*Defined in [near.ts:1478](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1478)*
 
 **Parameters:**
 
@@ -220,7 +220,7 @@ ___
 
 ▸ **promise_then**(promise_index: *`u32`*, method_name_len: *`usize`*, method_name_ptr: *`usize`*, args_len: *`usize`*, args_ptr: *`usize`*, amount: *`u64`*): `u32`
 
-*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1485)*
+*Defined in [near.ts:1485](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1485)*
 
 **Parameters:**
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **result_count**(): `u32`
 
-*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1465)*
+*Defined in [near.ts:1465](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1465)*
 
 **Returns:** `u32`
 
@@ -253,7 +253,7 @@ ___
 
 ▸ **result_is_ok**(index: *`u32`*): `bool`
 
-*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1467)*
+*Defined in [near.ts:1467](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1467)*
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ___
 
 ▸ **return_promise**(promise_index: *`u32`*): `void`
 
-*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1472)*
+*Defined in [near.ts:1472](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1472)*
 
 **Parameters:**
 
@@ -287,7 +287,7 @@ ___
 
 ▸ **return_value**(value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1470)*
+*Defined in [near.ts:1470](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1470)*
 
 **Parameters:**
 
@@ -305,7 +305,7 @@ ___
 
 ▸ **storage_has_key**(key_len: *`usize`*, key_ptr: *`usize`*): `bool`
 
-*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1456)*
+*Defined in [near.ts:1456](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1456)*
 
 **Parameters:**
 
@@ -323,7 +323,7 @@ ___
 
 ▸ **storage_iter**(prefix_len: *`usize`*, prefix_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1458)*
+*Defined in [near.ts:1458](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1458)*
 
 **Parameters:**
 
@@ -341,7 +341,7 @@ ___
 
 ▸ **storage_iter_next**(id: *`u32`*): `u32`
 
-*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1462)*
+*Defined in [near.ts:1462](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1462)*
 
 **Parameters:**
 
@@ -358,7 +358,7 @@ ___
 
 ▸ **storage_range**(start_len: *`usize`*, start_ptr: *`usize`*, end_len: *`usize`*, end_ptr: *`usize`*): `u32`
 
-*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1460)*
+*Defined in [near.ts:1460](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1460)*
 
 **Parameters:**
 
@@ -378,7 +378,7 @@ ___
 
 ▸ **storage_remove**(key_len: *`usize`*, key_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1454)*
+*Defined in [near.ts:1454](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1454)*
 
 **Parameters:**
 
@@ -396,7 +396,7 @@ ___
 
 ▸ **storage_write**(key_len: *`usize`*, key_ptr: *`usize`*, value_len: *`usize`*, value_ptr: *`usize`*): `void`
 
-*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1452)*
+*Defined in [near.ts:1452](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1452)*
 
 **Parameters:**
 

--- a/apidoc/modules/_near_.near.md
+++ b/apidoc/modules/_near_.near.md
@@ -32,7 +32,7 @@
 
 ▸ **base58**(source: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1193)*
+*Defined in [near.ts:1193](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1193)*
 
 **Parameters:**
 
@@ -49,7 +49,7 @@ ___
 
 ▸ **bytesToString**(bytes: *`Uint8Array`*): `string`
 
-*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1115)*
+*Defined in [near.ts:1115](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1115)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ ___
 
 ▸ **hash**<`T`>(data: *`T`*): `Uint8Array`
 
-*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1143)*
+*Defined in [near.ts:1143](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1143)*
 
 Hash given data. Returns hash as 32-byte array.
 
@@ -88,7 +88,7 @@ ___
 
 ▸ **hash32**<`T`>(data: *`T`*): `u32`
 
-*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1158)*
+*Defined in [near.ts:1158](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1158)*
 
 Hash given data. Returns hash as 32-bit integer.
 
@@ -110,7 +110,7 @@ ___
 
 ▸ **log**(msg: *`string`*): `void`
 
-*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1184)*
+*Defined in [near.ts:1184](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1184)*
 
 **Parameters:**
 
@@ -127,7 +127,7 @@ ___
 
 ▸ **parseFromBytes**<`T`>(bytes: *`Uint8Array`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1103)*
+*Defined in [near.ts:1103](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1103)*
 
 Parses the given bytes array to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -151,7 +151,7 @@ ___
 
 ▸ **parseFromString**<`T`>(s: *`string`*, defaultValue?: *`T`*): `T`
 
-*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1075)*
+*Defined in [near.ts:1075](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1075)*
 
 Parses the given string to return a value of the given generic type. Supported types: bool, integer, string and data objects defined in model.ts.
 
@@ -175,7 +175,7 @@ ___
 
 ▸ **random32**(): `u32`
 
-*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1180)*
+*Defined in [near.ts:1180](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1180)*
 
 Returns random 32-bit integer.
 
@@ -188,7 +188,7 @@ ___
 
 ▸ **randomBuffer**(len: *`u32`*): `Uint8Array`
 
-*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1171)*
+*Defined in [near.ts:1171](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1171)*
 
 Returns random byte buffer of given length.
 
@@ -207,7 +207,7 @@ ___
 
 ▸ **str**<`T`>(value: *`T`*): `string`
 
-*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1188)*
+*Defined in [near.ts:1188](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1188)*
 
 **Type parameters:**
 
@@ -227,7 +227,7 @@ ___
 
 ▸ **stringToBytes**(s: *`string`*): `Uint8Array`
 
-*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/4c31143/near.ts#L1119)*
+*Defined in [near.ts:1119](https://github.com/nearprotocol/near-runtime-ts/blob/273b67b/near.ts#L1119)*
 
 **Parameters:**
 

--- a/as-pect.config.js
+++ b/as-pect.config.js
@@ -17,6 +17,8 @@ module.exports = {
     "--binaryFile": ["output.wasm"],
     /** To enable wat file output, use the following flag. The filename is ignored, but required by the compiler. */
     // "--textFile": ["output.wat"],
+    /** To select an appropriate runtime, use the --runtime compiler flag. */
+    "--runtime": ["stub"] // Acceptable values are: full, half, stub (arena), and none
   },
   /**
    * A set of regexp that will disclude source files from testing.
@@ -30,26 +32,22 @@ module.exports = {
    * All performance statistics reporting can be configured here.
    */
   performance: {
-    /** Enable performance statistics gathering. */
+    /** Enable performance statistics gathering for every test. */
     enabled: false,
-    /** Set the maximum number of samples to run for each test. */
+    /** Set the maximum number of samples to run for every test. */
     maxSamples: 10000,
-    /** Set the maximum test run time in milliseconds. */
+    /** Set the maximum test run time in milliseconds for every test. */
     maxTestRunTime: 2000,
-    /** Set the number of decimal places to round to. */
-    roundDecimalPlaces: 3,
-    /** Report the median time in the default reporter. */
+    /** Report the median time in the default reporter for every test. */
     reportMedian: true,
-    /** Report the average time in milliseconds. */
+    /** Report the average time in milliseconds for every test. */
     reportAverage: true,
-    /** Report the standard deviation. */
+    /** Report the standard deviation for every test. */
     reportStandardDeviation: false,
-    /** Report the maximum run time in milliseconds. */
+    /** Report the maximum run time in milliseconds for every test. */
     reportMax: false,
-    /** Report the minimum run time in milliseconds. */
+    /** Report the minimum run time in milliseconds for every test. */
     reportMin: false,
-    /** Report the variance. */
-    reportVariance: false,
   },
   /**
    * Add a custom reporter here if you want one. The following example is in typescript.
@@ -68,4 +66,8 @@ module.exports = {
    * }
    */
   // reporter: new CustomReporter(),
+  /**
+   * Specify if the binary wasm file should be written to the file system.
+   */
+  outputBinary: false,
 };

--- a/bignum
+++ b/bignum
@@ -1,0 +1,1 @@
+node_modules/bignum/assembly/

--- a/near.ts
+++ b/near.ts
@@ -856,7 +856,7 @@ export namespace collections {
      * @returns an array of key to rating pairs for the given keys.
      */
     keysToRatings(keys: K[]): near.MapEntry<K, i32>[] {
-      let result = new Array<near.MapEntry<K, i32>>(keys.length);
+      let result = Array.create<near.MapEntry<K, i32>>(keys.length);
       for (let index = 0; index < keys.length; ++index) {
         let key = keys[index];
         result[index] = new near.MapEntry<K, i32>(key, this._ratings.get(key));
@@ -1322,8 +1322,7 @@ export class ContractPromise {
       id: promise_create(
         contractName.lengthUTF8 - 1, contractName.toUTF8(),
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
-        args.byteLength, args.dataStart,
-          amount.toUint8Array().dataStart)
+        args.byteLength, args.dataStart, amount.toUint8Array().dataStart)
     };
   }
 
@@ -1439,7 +1438,7 @@ export class ContractPromise {
    */
   static getResults() : ContractPromiseResult[] {
     let count = <i32>result_count();
-    let results = new Array<ContractPromiseResult>(count);
+    let results = Array.create<ContractPromiseResult>(count);
     for (let i = 0; i < count; i++) {
       let isOk = result_is_ok(i);
       if (!isOk) {

--- a/near.ts
+++ b/near.ts
@@ -1018,14 +1018,18 @@ class Context {
    * The amount of tokens received with this execution call.
    */
   get receivedAmount(): u128 {
-    return received_amount();
+    let buffer = new Uint8Array(16);
+    received_amount(buffer.dataStart);
+    return u128.fromBytes(<Uint8Array>buffer);
   }
 
   /**
    * The amount of tokens that are locked in the account. Storage usage fee is deducted from this balance.
    */
   get frozenBalance(): u128 {
-    return frozen_balance();
+    let buffer = new Uint8Array(16);
+    frozen_balance(buffer.dataStart);
+    return u128.fromBytes(<Uint8Array>buffer);
   }
 
   /**
@@ -1033,7 +1037,9 @@ class Context {
    * through cross-contract calls.
    */
   get liquidBalance(): u128 {
-      return liquid_balance();
+    let buffer = new Uint8Array(16);
+    liquid_balance(buffer.dataStart);
+    return u128.fromBytes(<Uint8Array>buffer);
   }
 
   /**
@@ -1049,7 +1055,11 @@ class Context {
    * Will fail if there is less than minimum amount on the liquid balance. Returns the deposited amount.
    */
   deposit(minAmount: u128, maxAmount: u128): u128 {
-    deposit(minAmount, maxAmount)
+    let minAmountBuffer = minAmount.toUint8Array();
+    let maxAmountBuffer = maxAmount.toUint8Array();
+    let balanceBuffer = new Uint8Array(16);
+    deposit(minAmountBuffer.dataStart, maxAmountBuffer.dataStart, balanceBuffer.dataStart);
+    return u128.fromBytes(<Uint8Array>balanceBuffer);
   }
 
    /**
@@ -1058,7 +1068,11 @@ class Context {
    * Will fail if there is less than minimum amount on the frozen balance. Returns the withdrawn amount.
    */
   withdraw(minAmount: u128, maxAmount: u128): u128 {
-    withdraw(minAmount, maxAmount)
+     let minAmountBuffer = minAmount.toUint8Array();
+     let maxAmountBuffer = maxAmount.toUint8Array();
+     let balanceBuffer = new Uint8Array(16);
+     withdraw(minAmountBuffer.dataStart, maxAmountBuffer.dataStart, balanceBuffer.dataStart);
+     return u128.fromBytes(<Uint8Array>balanceBuffer);
   }
 }
 
@@ -1309,7 +1323,7 @@ export class ContractPromise {
         contractName.lengthUTF8 - 1, contractName.toUTF8(),
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
         args.byteLength, <usize>args.buffer + args.byteOffset,
-        amount)
+        amount.toUint8Array().dataStart)
     };
   }
 
@@ -1331,7 +1345,7 @@ export class ContractPromise {
         this.id,
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
         args.byteLength, <usize>args.buffer + args.byteOffset,
-        amount)
+        amount.toUint8Array().dataStart)
     };
   }
 
@@ -1481,14 +1495,14 @@ declare function promise_create(
     account_id_len: usize, account_id_ptr: usize,
     method_name_len: usize, method_name_ptr: usize,
     args_len: usize, args_ptr: usize,
-    amount: u128): u32;
+    amount_ptr: usize): u32;
 
 @external("env", "promise_then")
 declare function promise_then(
     promise_index: u32,
     method_name_len: usize, method_name_ptr: usize,
     args_len: usize, args_ptr: usize,
-    amount: u128): u32;
+    amount_ptr: usize): u32;
 
 @external("env", "promise_and")
 declare function promise_and(promise_index1: u32, promise_index2: u32): u32;
@@ -1496,9 +1510,9 @@ declare function promise_and(promise_index1: u32, promise_index2: u32): u32;
 @external("env", "check_ethash")
 declare function check_ethash(
     block_number: u64,
-    header_hash_ptr: u32, header_hash_len: u32,
+    header_hash_ptr: usize, header_hash_len: u32,
     nonce: u64,
-    mix_hash_ptr: u32, mix_hash_len: u32,
+    mix_hash_ptr: usize, mix_hash_len: u32,
     difficulty: u64
 ): bool;
 
@@ -1538,13 +1552,13 @@ declare function _near_log(msg_ptr: usize): void;
  * @hidden
  */
 @external("env", "frozen_balance")
-declare function frozen_balance(): u128;
+declare function frozen_balance(balance_ptr: usize): void;
 
 /**
  * @hidden
  */
 @external("env", "liquid_balance")
-declare function liquid_balance(): u128;
+declare function liquid_balance(balance_ptr: usize): void;
 
 /**
  * @hidden
@@ -1556,19 +1570,19 @@ declare function storage_usage(): u64;
  * @hidden
  */
 @external("env", "deposit")
-declare function deposit(min_amount: u128, max_amount: u128): u128;
+declare function deposit(min_amount_ptr: usize, max_amount_ptr: usize, balance_ptr: usize): void;
 
 /**
  * @hidden
  */
 @external("env", "withdraw")
-declare function withdraw(min_amount: u128, max_amount: u128): u128;
+declare function withdraw(min_amount_ptr: usize, max_amount_ptr: usize, balance_ptr: usize): void;
 
 /**
  * @hidden
  */
 @external("env", "received_amount")
-declare function received_amount(): u128;
+declare function received_amount(balance_ptr: usize): void;
 
 /**
  * @hidden

--- a/near.ts
+++ b/near.ts
@@ -94,7 +94,7 @@ export class Storage {
    * It's convenient to use this together with `domainObject.encode()`.
    */
   setBytes(key: string, value: Uint8Array): void {
-    storage_write(key.lengthUTF8 - 1, key.toUTF8(), value.byteLength, value.buffer.data);
+    storage_write(key.lengthUTF8 - 1, key.toUTF8(), value.byteLength, <usize>value.buffer + value.byteOffset);
   }
 
   /**
@@ -201,7 +201,7 @@ export class Storage {
         keyLen,
         key,
         this._scratchBuf.byteLength,
-        this._scratchBuf.buffer.data,
+        <usize>this._scratchBuf.buffer + this._scratchBuf.byteOffset,
       );
       if (len <= <usize>(this._scratchBuf.byteLength)) {
         return len;
@@ -221,7 +221,7 @@ export class Storage {
     if (len == 0) {
       return null;
     }
-    return String.fromUTF8(this._scratchBuf.buffer.data, len);
+    return String.fromUTF8(<usize>this._scratchBuf.buffer + this._scratchBuf.byteOffset, len);
   }
 
   /**
@@ -234,7 +234,7 @@ export class Storage {
       return null;
     }
     let res = new Uint8Array(len);
-    memory.copy(res.buffer.data, this._scratchBuf.buffer.data, len);
+    memory.copy(<usize>res.buffer, <usize>this._scratchBuf.buffer + this._scratchBuf.byteOffset, len);
     return res;
   }
 }
@@ -1113,13 +1113,13 @@ export namespace near {
   }
 
   export function bytesToString(bytes: Uint8Array): string {
-    return String.fromUTF8(bytes.buffer.data + bytes.byteOffset, bytes.byteLength)
+    return String.fromUTF8(<usize>bytes.buffer + bytes.byteOffset, bytes.byteLength)
   }
 
   export function stringToBytes(s: string): Uint8Array {
     let len = s.lengthUTF8 - 1;
     let bytes = new Uint8Array(len);
-    memory.copy(bytes.buffer.data, s.toUTF8(), len);
+    memory.copy(<usize>bytes.buffer, s.toUTF8(), len);
     return bytes;
   }
 
@@ -1143,10 +1143,10 @@ export namespace near {
   export function hash<T>(data: T): Uint8Array {
     let result = new Uint8Array(32);
     if (data instanceof Uint8Array) {
-      _near_hash(data.byteLength, data.buffer.data, result.buffer.data);
+      _near_hash(data.byteLength, <usize>data.buffer + data.byteOffset, <usize>result.buffer);
     } else {
       let str = data.toString();
-      _near_hash(str.lengthUTF8 - 1, str.toUTF8(), result.buffer.data);
+      _near_hash(str.lengthUTF8 - 1, str.toUTF8(), <usize>result.buffer);
     }
     return result;
   }
@@ -1158,7 +1158,7 @@ export namespace near {
   export function hash32<T>(data: T): u32 {
     let dataToHash : Uint8Array;
     if (data instanceof Uint8Array) {
-      return _near_hash32(data.byteLength, data.buffer.data);
+      return _near_hash32(data.byteLength, <usize>data.buffer + data.byteOffset);
     } else {
       let str = data.toString();
       return _near_hash32(str.lengthUTF8 - 1, str.toUTF8());
@@ -1170,7 +1170,7 @@ export namespace near {
    */
   export function randomBuffer(len: u32): Uint8Array {
     let result = new Uint8Array(len);
-    _near_random_buf(len, result.buffer.data);
+    _near_random_buf(len, <usize>result.buffer);
     return result;
   }
 
@@ -1306,7 +1306,7 @@ export class ContractPromise {
       id: promise_create(
         contractName.lengthUTF8 - 1, contractName.toUTF8(),
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
-        args.byteLength, args.buffer.data,
+        args.byteLength, <usize>args.buffer + args.byteOffset,
         amount)
     };
   }
@@ -1328,7 +1328,7 @@ export class ContractPromise {
       id: promise_then(
         this.id,
         methodName.lengthUTF8 - 1, methodName.toUTF8(),
-        args.byteLength, args.buffer.data,
+        args.byteLength, <usize>args.buffer + args.byteOffset,
         amount)
     };
   }

--- a/near.ts
+++ b/near.ts
@@ -1,4 +1,4 @@
-import { u128 } from "./node_modules/bignum/assembly/integer/u128";
+import { u128 } from "./bignum/integer/u128";
 
 const DEFAULT_SCRATCH_BUFFER_SIZE: usize = 1 << 16;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -46,9 +52,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.129",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.129.tgz",
-      "integrity": "sha512-oYaV0eSlnOacOr7i4X1FFdH8ttSlb57gu3I9MuStIv2CYkISEY84dNHYsC3bF6sNH7qYcu1BtVrCtQ8Q4KPTfQ==",
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
       "dev": true
     },
     "@types/marked": {
@@ -64,9 +70,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
+      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
       "dev": true
     },
     "@types/shelljs": {
@@ -153,6 +159,7 @@
       "from": "github:jtenner/as-pect",
       "dev": true,
       "requires": {
+        "assemblyscript": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
         "chalk": "^2.4.2",
         "csv-stringify": "^5.3.0",
         "glob": "^7.1.4",
@@ -160,33 +167,6 @@
         "mathjs": "^6.0.1",
         "ts-node": "^8.2.0",
         "yargs-parser": "^13.1.0"
-      },
-      "dependencies": {
-        "assemblyscript": {
-          "version": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
-          "from": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
-          "requires": {
-            "@protobufjs/utf8": "^1.1.0",
-            "binaryen": "84.0.0-nightly.20190522",
-            "glob": "^7.1.4",
-            "long": "^4.0.0",
-            "opencollective-postinstall": "^2.0.0",
-            "source-map-support": "^0.5.12"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "asn1": {
@@ -196,6 +176,19 @@
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
+      }
+    },
+    "assemblyscript": {
+      "version": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
+      "from": "github:assemblyscript/assemblyscript",
+      "dev": true,
+      "requires": {
+        "@protobufjs/utf8": "^1.1.0",
+        "binaryen": "84.0.0-nightly.20190522",
+        "glob": "^7.1.4",
+        "long": "^4.0.0",
+        "opencollective-postinstall": "^2.0.0",
+        "source-map-support": "^0.5.12"
       }
     },
     "assert-plus": {
@@ -231,7 +224,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -247,10 +241,17 @@
       "from": "github:MaxGraey/bignum.wasm",
       "dev": true
     },
+    "binaryen": {
+      "version": "84.0.0-nightly.20190522",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-84.0.0-nightly.20190522.tgz",
+      "integrity": "sha512-bxSPi3MOkFmK5W6VIlqxnOc1nYzpUCzT/tHz3C7sgbz7jTR2lOBlZnKStTJlBt018xeZK9/JpK/jXdduH7eQFg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -265,7 +266,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -330,7 +332,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -554,7 +557,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -620,9 +624,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.15.6",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
+      "version": "9.15.8",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -658,6 +662,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -666,7 +671,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "interpret": {
       "version": "1.2.0",
@@ -808,7 +814,8 @@
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "make-error": {
       "version": "1.3.5",
@@ -857,6 +864,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -889,9 +897,16 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
     },
     "optimist": {
       "version": "0.6.1",
@@ -934,7 +949,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -967,9 +983,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
       "dev": true
     },
     "punycode": {
@@ -1106,12 +1122,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
       "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -1150,9 +1168,9 @@
       }
     },
     "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "tiny-emitter": {
@@ -1279,9 +1297,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
-      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1371,7 +1389,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,31 +152,20 @@
       "dev": true
     },
     "as-pect": {
-      "version": "github:jtenner/as-pect#5d8ef1559ff3841973860ee82c425a552b94b335",
+      "version": "github:jtenner/as-pect#7a915596287c3ea939f1fa31b7708867dea21428",
       "from": "github:jtenner/as-pect",
       "dev": true,
       "requires": {
-        "assemblyscript": "github:assemblyscript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3",
+        "assemblyscript": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
         "chalk": "^2.4.2",
+        "csv-stringify": "^5.3.0",
         "glob": "^7.1.4",
-        "mathjs": "^5.10.0",
-        "ts-node": "^8.1.0",
+        "long": "^4.0.0",
+        "mathjs": "^6.0.1",
+        "ts-node": "^8.2.0",
         "yargs-parser": "^13.1.0"
       },
       "dependencies": {
-        "assemblyscript": {
-          "version": "github:assemblyscript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3",
-          "from": "github:assemblyscript/assemblyscript",
-          "dev": true,
-          "requires": {
-            "@protobufjs/utf8": "^1.1.0",
-            "binaryen": "77.0.0-nightly.20190407",
-            "glob": "^7.1.3",
-            "long": "^4.0.0",
-            "opencollective-postinstall": "^2.0.0",
-            "source-map-support": "^0.5.11"
-          }
-        },
         "glob": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -203,22 +192,31 @@
       }
     },
     "assemblyscript": {
-      "version": "github:nearprotocol/assemblyscript#97ddc48011d0875cac131e9847cee1f2a3cf523e",
-      "from": "github:nearprotocol/assemblyscript",
+      "version": "github:assemblyscript/assemblyscript#addb99eff250af2af0241442d45ff3d23434e6f1",
+      "from": "github:assemblyscript/assemblyscript",
       "dev": true,
       "requires": {
         "@protobufjs/utf8": "^1.1.0",
-        "binaryen": "69.0.0-nightly.20190228",
-        "glob": "^7.1.3",
+        "binaryen": "84.0.0-nightly.20190522",
+        "glob": "^7.1.4",
         "long": "^4.0.0",
-        "source-map-support": "^0.5.10"
+        "opencollective-postinstall": "^2.0.0",
+        "source-map-support": "^0.5.12"
       },
       "dependencies": {
-        "binaryen": {
-          "version": "69.0.0-nightly.20190228",
-          "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-69.0.0-nightly.20190228.tgz",
-          "integrity": "sha512-rF3UuWKyYc0+PX+HteNKB3rl5FIcwIfmCldFp2PShJ9lwUvTLqvMaGfco6/QhFSP0Q0iLdHxBFDn9LHief8FPg==",
-          "dev": true
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -268,9 +266,9 @@
       }
     },
     "binaryen": {
-      "version": "77.0.0-nightly.20190407",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz",
-      "integrity": "sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg==",
+      "version": "84.0.0-nightly.20190522",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-84.0.0-nightly.20190522.tgz",
+      "integrity": "sha512-bxSPi3MOkFmK5W6VIlqxnOc1nYzpUCzT/tHz3C7sgbz7jTR2lOBlZnKStTJlBt018xeZK9/JpK/jXdduH7eQFg==",
       "dev": true
     },
     "brace-expansion": {
@@ -382,6 +380,15 @@
         "cssom": "0.3.x"
       }
     },
+    "csv-stringify": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
+      "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -440,9 +447,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
     "domexception": {
@@ -816,6 +823,12 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -841,9 +854,9 @@
       "dev": true
     },
     "mathjs": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-5.10.0.tgz",
-      "integrity": "sha512-AWvw1VRZv/37TlHGyAdUPc8U59jHE1cT4jfmM5D7Z18uUaGPqpG59Ia5VvQosxvO71KNBxXAImfxTwEt+6fA3A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-6.0.2.tgz",
+      "integrity": "sha512-K3Q0qoZx7iFz0PnFC0b4kIRZPBQq6rg4htRGnLU4o7SvBTNZnACaUrqqk6sQ891aa7maCDKp8PK1J8YyDAmw2g==",
       "dev": true,
       "requires": {
         "complex.js": "2.0.11",
@@ -1210,13 +1223,13 @@
       }
     },
     "ts-node": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
-      "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz",
+      "integrity": "sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
-        "diff": "^3.1.0",
+        "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
@@ -1419,9 +1432,9 @@
       "dev": true
     },
     "yargs-parser": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-      "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "as-pect": "jtenner/as-pect",
+    "bignum": "MaxGraey/bignum.wasm",
     "typedoc": "^0.14.2",
-    "typedoc-plugin-markdown": "^1.1.25",
-    "as-pect": "github:jtenner/as-pect",
-    "bignum": "github:MaxGraey/bignum.wasm"
+    "typedoc-plugin-markdown": "^1.1.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "index.js",
   "scripts": {
     "doc": "rm -rf apidoc; mkdir apidoc; node_modules/.bin/typedoc near.ts --theme markdown --ignoreCompilerErrors --excludePrivate --excludeProtected --excludeExternals --out apidoc/",
-    "test": "cp node_modules/as-pect/assembly/__tests__/as-pect.d.ts assembly/__tests__/; asp"
+    "test": "asp"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "as-pect": "github:jtenner/as-pect",
     "typedoc": "^0.14.2",
-    "typedoc-plugin-markdown": "^1.1.25",
-    "as-pect": "jtenner/as-pect"
+    "typedoc-plugin-markdown": "^1.1.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "main": "index.js",
   "scripts": {
     "doc": "rm -rf apidoc; mkdir apidoc; node_modules/.bin/typedoc near.ts --theme markdown --ignoreCompilerErrors --excludePrivate --excludeProtected --excludeExternals --out apidoc/",
-    "test": "cp node_modules/as-pect/assembly/__tests__/as-pect.d.ts assembly/__tests__/; asp"
+    "test": "asp --types; asp"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "as-pect": "jtenner/as-pect",
+    "as-pect": "github:jtenner/as-pect",
     "bignum": "MaxGraey/bignum.wasm",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-runtime-ts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Near smart contract runtime library for typescript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update assemblyscript syntax, use u128 to comply with nightshade updates, and expose `check_ethash`. Requires https://github.com/MaxGraey/bignum.wasm/pull/17.