### PR TITLE
Update contract API to use generic

### DIFF
--- a/assembly/contract.ts
+++ b/assembly/contract.ts
@@ -99,7 +99,7 @@ class Context {
 *   let promise = ContractPromise.create(
 *     "metanear",
 *     "addItem",
-*     itemArgs.encode(),
+*     itemArgs,
 *     0,
 *   );
 *   // Setting up args for the callback
@@ -126,37 +126,36 @@ export class ContractPromise {
   * without errors or failed asserts.
   * @param contractName Account ID of the remote contract to call. E.g. `metanear`.
   * @param methodName Method name on the remote contract to call. E.g. `addItem`.
-  * @param args Serialized arguments to pass into the method. To get them create a new model
+  * @param args Arguments object which will be serialized and passed into the method. To get them create a new model
   *     specific for the method you calling, e.g. `AddItemArgs`. Then create an instance of it
-  *     and populate arguments. After this, serialize it into bytes. E.g.
+  *     and populate arguments. E.g.
   *     ```
   *     let itemArgs: AddItemArgs = {
   *       accountId: "alice.near",
   *       itemId: "Sword +9000",
   *     };
-  *     // Serialize args
-  *     let args = itemArgs.encode();
   *     ```
   * @param gas The amount of gas attached to the call
   * @param amount The amount of tokens from your contract to be sent to the remote contract with this call.
   */
-  static create(
+  static create<T>(
     contractName: string,
     methodName: string,
-    args: Uint8Array,
+    args: T,
     gas: u64,
     amount: u128 = u128.fromU64(0)
   ): ContractPromise {
     const contract_name_encoded = util.stringToBytes(contractName);
     const method_name_encoded = util.stringToBytes(methodName);
     let amount_arr = amount.toUint8Array();
+    const bytes = encode<T>(args);
     const id: u64 = runtime_api.promise_create(
       contract_name_encoded.byteLength,
       contract_name_encoded.dataStart,
       method_name_encoded.byteLength,
       method_name_encoded.dataStart,
-      args.byteLength,
-      args.dataStart,
+      bytes.byteLength,
+      bytes.dataStart,
       amount_arr.dataStart,
       gas);
       //@ts-ignore: Typescript expects the object to have a function to match the type
@@ -172,28 +171,29 @@ export class ContractPromise {
   * @param methodName Method name on your contract to be called to receive the callback.
   *     NOTE: Your callback method name can start with `_`, which would prevent other
   *     contracts from calling it directly. Only callbacks can call methods with `_` prefix.
-  * @param args Serialized arguments on your callback method, see `create` for details.
+  * @param args Arguments on your callback method which will be serailized, see `create` for details.
   * @param gas The amount of gas attached to the call.
   * @param amount The amount of tokens from the called contract to be sent to the current contract with this call.
   */
-  then(
+  then<T>(
     contractName: string,
     methodName: string,
-    args: Uint8Array,
+    args: T,
     gas: u64,
     amount: u128 = u128.fromU64(0)
   ): ContractPromise {
     const contract_name_encoded = util.stringToBytes(contractName);
     const method_name_encoded = util.stringToBytes(methodName);
     let amount_arr = amount.toUint8Array();
+    const bytes = encode<T>(args);
     const id = runtime_api.promise_then(
       this.id,
       contract_name_encoded.byteLength,
       contract_name_encoded.dataStart,
       method_name_encoded.byteLength,
       method_name_encoded.dataStart,
-      args.byteLength,
-      args.dataStart,
+      bytes.byteLength,
+      bytes.dataStart,
       amount_arr.dataStart,
       gas);
       //@ts-ignore: See above ignore comment

--- a/assembly/storage.ts
+++ b/assembly/storage.ts
@@ -138,6 +138,7 @@ export class Storage {
   get<T>(key: string, defaultValue: T | null = null): T | null {
     if (isString<T>()) {
       const strValue = this.getString(key);
+      //@ts-ignore getString is non-null
       return strValue == null ? defaultValue : util.parseFromString<T>(this.getString(key));
     } else {
       const byteValue = this.getBytes(key);
@@ -156,6 +157,7 @@ export class Storage {
   getPrimitive<T>(key: string, defaultValue: T): T {
     if (isInteger<T>()) {
       const strValue = this.getString(key);
+      //@ts-ignore getString is non-null
       return strValue == null ? defaultValue : util.parseFromString<T>(this.getString(key));
     } else {
       throw "Operation not supported. Please use storage.get<T> for non-primitives";
@@ -174,8 +176,10 @@ export class Storage {
   getSome<T>(key: string): T {
     assert(this.hasKey(key), "Key is not present in the storage");
     if (isString<T>() || isInteger<T>()) {
+      //@ts-ignore assert means key exists
       return util.parseFromString<T>(this.getString(key));
     } else {
+      //@ts-ignore assert means key exists
       return util.parseFromBytes<T>(this.getBytes(key));
     }
   }

--- a/assembly/util.ts
+++ b/assembly/util.ts
@@ -35,9 +35,9 @@ export namespace util {
   */
   export function parseFromBytes<T>(bytes: Uint8Array): T {
     if (isString<T>() || isInteger<T>()) {
+      //@ts-ignore bytes is non-null so output will be nun-null
       return parseFromString<T>(bytesToString(bytes));
     } else {
-      //@ts-ignore v will have decode. Although second parameter is optional it causes compile error
       return decode<T>(bytes);
     }
   }
@@ -65,7 +65,6 @@ export namespace util {
         return <T>U64.parseInt(s);
       }
     } else {
-      //@ts-ignore v will have decode method
       return decode<T>(stringToBytes(s));
     }
   }

--- a/tests/assembly/hello/main.ts
+++ b/tests/assembly/hello/main.ts
@@ -1,7 +1,8 @@
 //@nearfile out
-import { context, storage, ContractPromise, near, logging } from "near-runtime-ts";
+import { context, storage, ContractPromise, near, logging, util } from "near-runtime-ts";
 
 import { PromiseArgs, InputPromiseArgs, MyCallbackResult, MyContractPromiseResult } from "./model";
+
 
 import { u128 } from "bignum";
 
@@ -142,10 +143,10 @@ export function recurse(n: i32): i32 {
 export function callPromise(args: PromiseArgs): void {
   let inputArgs: InputPromiseArgs = { args: args.args };
   let balance = args.balance as u64;
-  let promise = ContractPromise.create(
+  let promise = ContractPromise.create<InputPromiseArgs>(
       args.receiver,
       args.methodName,
-      inputArgs.encode(),
+      inputArgs,
       args.gas,
       new u128(args.balance)
       );
@@ -153,10 +154,10 @@ export function callPromise(args: PromiseArgs): void {
     inputArgs.args = args.callbackArgs;
     let callbackBalance = args.callbackBalance as u64;
 
-    promise = promise.then(
+    promise = promise.then<InputPromiseArgs>(
         context.contractName,
         args.callback,
-        inputArgs.encode(),
+        inputArgs,
         args.callbackGas,
         new u128(callbackBalance)
     );

--- a/tests/assembly/main.ts
+++ b/tests/assembly/main.ts
@@ -93,330 +93,330 @@ export function storageGenericGetSetRoundtripTest(): void {
   assert(storage.get<string>("nonexistent", null) == null, "Incorrect data value for get<T> string nonexistent key");
 }
 
-export function storageKeysTest(): string[] {
-  logging.log("storageKeysTest");
+// export function storageKeysTest(): string[] {
+//   logging.log("storageKeysTest");
 
-  // empty storage
-  const emptyKeys = storage.keys("someKey");
-  assert(emptyKeys.length == 0, "Incorrect keys contents for empty storage");
+//   // empty storage
+//   const emptyKeys = storage.keys("someKey");
+//   assert(emptyKeys.length == 0, "Incorrect keys contents for empty storage");
 
-  // add some keys
-  storage.setString("someApple", "myApple");
-  storage.setString("someKey", "myValue1");
-  storage.setString("someKey2", "myValue1");
-  storage.setString("someKey6", "myValue2");
+//   // add some keys
+//   storage.setString("someApple", "myApple");
+//   storage.setString("someKey", "myValue1");
+//   storage.setString("someKey2", "myValue1");
+//   storage.setString("someKey6", "myValue2");
 
-  const keyRange = storage.keyRange("someKey", "someKey3");
-  assert(keyRange.length == 2, "Incorrect keys length");
-  assert(keyRange[0] == "someKey", "Incorrect keys contents");
-  assert(keyRange[1] == "someKey2", "Incorrect keys contents");
-  const keyRangeWithLimit = storage.keyRange("someKey", "someKey3", 1);
-  assert(keyRangeWithLimit.length == 1, "Incorrect keys length");
-  assert(keyRangeWithLimit[0] == "someKey", "Incorrect keys contents");
+//   const keyRange = storage.keyRange("someKey", "someKey3");
+//   assert(keyRange.length == 2, "Incorrect keys length");
+//   assert(keyRange[0] == "someKey", "Incorrect keys contents");
+//   assert(keyRange[1] == "someKey2", "Incorrect keys contents");
+//   const keyRangeWithLimit = storage.keyRange("someKey", "someKey3", 1);
+//   assert(keyRangeWithLimit.length == 1, "Incorrect keys length");
+//   assert(keyRangeWithLimit[0] == "someKey", "Incorrect keys contents");
 
-  const keys = storage.keys("someKey");
-  assert(keys.length == 3, "Incorrect keys length");
-  assert(keys[0] == "someKey", "Incorrect keys contents");
-  assert(keys[1] == "someKey2", "Incorrect keys contents");
-  assert(keys[2] == "someKey6", "Incorrect keys contents");
-  const keysWithLimit = storage.keys("someKey", 1);
-  assert(keysWithLimit.length == 1, "Incorrect keys length");
-  assert(keys[0] == "someKey", "Incorrect keys contents")
+//   const keys = storage.keys("someKey");
+//   assert(keys.length == 3, "Incorrect keys length");
+//   assert(keys[0] == "someKey", "Incorrect keys contents");
+//   assert(keys[1] == "someKey2", "Incorrect keys contents");
+//   assert(keys[2] == "someKey6", "Incorrect keys contents");
+//   const keysWithLimit = storage.keys("someKey", 1);
+//   assert(keysWithLimit.length == 1, "Incorrect keys length");
+//   assert(keys[0] == "someKey", "Incorrect keys contents")
 
-  assert(storage.contains("someApple"), "Storage does not contain key");
-  assert(storage.contains("someKey"), "Storage does not contain key");
-  assert(storage.contains("someKey2"), "Storage does not contain key");
-  assert(storage.contains("someKey6"), "Storage does not contain key");
-  assert(!storage.contains("nonexisting"), "Storage has unexpected key");
-  assert(storage.hasKey("someKey6"), "Storage does not contain key");
-  assert(!storage.hasKey("nonexisting"), "Storage has unexpected key");
+//   assert(storage.contains("someApple"), "Storage does not contain key");
+//   assert(storage.contains("someKey"), "Storage does not contain key");
+//   assert(storage.contains("someKey2"), "Storage does not contain key");
+//   assert(storage.contains("someKey6"), "Storage does not contain key");
+//   assert(!storage.contains("nonexisting"), "Storage has unexpected key");
+//   assert(storage.hasKey("someKey6"), "Storage does not contain key");
+//   assert(!storage.hasKey("nonexisting"), "Storage has unexpected key");
 
-  // remove a key and retry some of the api calls
-  storage.delete("someKey");
-  assert(!storage.contains("someKey"), "Storage contains key that was deleted");
-  assert(storage.contains("someKey2"), "Some other key got deleted");
-  const keyswithdelete = storage.keys("someKey");
-  assert(keyswithdelete.length == 2, "Incorrect keys length after removing a key")
-  assert(keyswithdelete[0] == "someKey2", "Incorrect keyswithdelete contents");
-  assert(keyswithdelete[1] == "someKey6", "Incorrect keyswithdelete contents");
-  return keyswithdelete;
-}
+//   // remove a key and retry some of the api calls
+//   storage.delete("someKey");
+//   assert(!storage.contains("someKey"), "Storage contains key that was deleted");
+//   assert(storage.contains("someKey2"), "Some other key got deleted");
+//   const keyswithdelete = storage.keys("someKey");
+//   assert(keyswithdelete.length == 2, "Incorrect keys length after removing a key")
+//   assert(keyswithdelete[0] == "someKey2", "Incorrect keyswithdelete contents");
+//   assert(keyswithdelete[1] == "someKey6", "Incorrect keyswithdelete contents");
+//   return keyswithdelete;
+// }
 
-export function mapTests(): void {
-  logging.log("mapTests");
-  // empty map
-  const map = new PersistentMap<string, TextMessage>("mapId");
-  const valuesEmpty = map.values("", "zzz");
-  assert(valuesEmpty.length == 0, "Unexpected values in empty map");
-  assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
-  assert(map.get("nonexistentkey") == null, "Incorrect result on get with nonexistent key");
+// export function mapTests(): void {
+//   logging.log("mapTests");
+//   // empty map
+//   const map = new PersistentMap<string, TextMessage>("mapId");
+//   const valuesEmpty = map.values("", "zzz");
+//   assert(valuesEmpty.length == 0, "Unexpected values in empty map");
+//   assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
+//   assert(map.get("nonexistentkey") == null, "Incorrect result on get with nonexistent key");
 
-  // add some entries to the map
-  const message = _testTextMessage();
-  map.set("mapKey1", message);
-  map.set("mapKey3", _testTextMessageTwo());
-  const values = map.values("", "zzz");
-  assert(values.length == 2, "Unexpected values size in map with 2 entries");
-  assert(_modelObjectEqual(values[0], message), "Unexpected values contents in map with 2 entries");
-  assert(_modelObjectEqual(values[1], _testTextMessageTwo()), "Unexpected values contents in map with 2 entries");
-  assert(map.values("mapKey3", "zzz").length == 1, "Unexpected values size in map with 2 entries");
-  assert(map.values("mapKey1", "mapKey2").length == 1, "Unexpected values size in map with 2 entries");
-  assert(map.values("mapKey1", "mapKey4", -1, false).length == 1, "Unexpected values size in map with 2 entries");
-  assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
-  assert(map.contains("mapKey1"), "Map does not contain a key that was added (mapKey1)");
-  assert(map.contains("mapKey3"), "Map does not contain a key that was added (mapKey3)");
-  assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get");
-  assert(_modelObjectEqual(map.get("mapKey3"), _testTextMessageTwo()), "Incorrect result from map get");
+//   // add some entries to the map
+//   const message = _testTextMessage();
+//   map.set("mapKey1", message);
+//   map.set("mapKey3", _testTextMessageTwo());
+//   const values = map.values("", "zzz");
+//   assert(values.length == 2, "Unexpected values size in map with 2 entries");
+//   assert(_modelObjectEqual(values[0], message), "Unexpected values contents in map with 2 entries");
+//   assert(_modelObjectEqual(values[1], _testTextMessageTwo()), "Unexpected values contents in map with 2 entries");
+//   assert(map.values("mapKey3", "zzz").length == 1, "Unexpected values size in map with 2 entries");
+//   assert(map.values("mapKey1", "mapKey2").length == 1, "Unexpected values size in map with 2 entries");
+//   assert(map.values("mapKey1", "mapKey4", -1, false).length == 1, "Unexpected values size in map with 2 entries");
+//   assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
+//   assert(map.contains("mapKey1"), "Map does not contain a key that was added (mapKey1)");
+//   assert(map.contains("mapKey3"), "Map does not contain a key that was added (mapKey3)");
+//   assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get");
+//   assert(_modelObjectEqual(map.get("mapKey3"), _testTextMessageTwo()), "Incorrect result from map get");
 
-  // delete an entry and retry api calls
-  map.delete("mapKey3");
-  assert(map.values("", "zzz").length == 1, "Unexpected values size in map after delete");
-  assert(_modelObjectEqual(map.values("", "zzz")[0], message), "Unexpected values contents in map after delete");
-  assert(map.values("mapKey1", "zzz").length == 1, "Unexpected values size in map after delete");
-  assert(!map.contains("mapKey3"), "Map contains a key that was deleted");
-  assert(map.contains("mapKey1"), "Map does not contain a key that should be there after deletion of another key");
-  assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get after delete");
-  assert(map.get("mapKey3") == null, "Incorrect result from map get on a deleted key");
-}
+//   // delete an entry and retry api calls
+//   map.delete("mapKey3");
+//   assert(map.values("", "zzz").length == 1, "Unexpected values size in map after delete");
+//   assert(_modelObjectEqual(map.values("", "zzz")[0], message), "Unexpected values contents in map after delete");
+//   assert(map.values("mapKey1", "zzz").length == 1, "Unexpected values size in map after delete");
+//   assert(!map.contains("mapKey3"), "Map contains a key that was deleted");
+//   assert(map.contains("mapKey1"), "Map does not contain a key that should be there after deletion of another key");
+//   assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get after delete");
+//   assert(map.get("mapKey3") == null, "Incorrect result from map get on a deleted key");
+// }
 
-export function mapTestsWithPrimitices(): void{
-  // map with primitives
-  const map = new PersistentMap<i32, i32>("mapPrimitives");
-  map.set(1, -20);
-  assert(map.getSome(1) == -20, "wrong value on map get for i32");
-}
+// export function mapTestsWithPrimitices(): void{
+//   // map with primitives
+//   const map = new PersistentMap<i32, i32>("mapPrimitives");
+//   map.set(1, -20);
+//   assert(map.getSome(1) == -20, "wrong value on map get for i32");
+// }
 
-export function vectorTests(): void {
-  logging.log("vectorTests");
-  const vector = new PersistentVector<string>("vector1");
-  assert(vector != null, "Vector not initialized");
-  assert(vector.length == 0, "Empty vector has incorrect length");
-  assert(!vector.containsIndex(0), "Empty vector incorrectly has index 0");
-  assert(vector.isEmpty, "isEmpty incorrect on empty vector");
-  //try { assert(vector[0] == null, "");} catch (e) {} not possible to test due to lack of try catch
+// export function vectorTests(): void {
+//   logging.log("vectorTests");
+//   const vector = new PersistentVector<string>("vector1");
+//   assert(vector != null, "Vector not initialized");
+//   assert(vector.length == 0, "Empty vector has incorrect length");
+//   assert(!vector.containsIndex(0), "Empty vector incorrectly has index 0");
+//   assert(vector.isEmpty, "isEmpty incorrect on empty vector");
+//   //try { assert(vector[0] == null, "");} catch (e) {} not possible to test due to lack of try catch
 
-  vector.push("bb");
-  assert(vector.length == 1, "Vector has incorrect length");
-  assert(vector.containsIndex(0), "Non empty vector does not have index 0");
-  assert(!vector.containsIndex(1), "Vector size 1 incorrectly has index 1");
-  assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
-  assert(vector.back == "bb", "Incorrect back entry");
-  assert(vector.last == "bb", "Incorrect last entry");
-  assert(vector.front == "bb", "Incorrect front entry");
-  assert(vector.first == "bb", "Incorrect first entry");
-  assert(vector[0] == "bb", "incorrect vector contents");
-  assert(_vectorHasContents(vector, ["bb"]), "Unexpected vector contents. Expected [bb]");
+//   vector.push("bb");
+//   assert(vector.length == 1, "Vector has incorrect length");
+//   assert(vector.containsIndex(0), "Non empty vector does not have index 0");
+//   assert(!vector.containsIndex(1), "Vector size 1 incorrectly has index 1");
+//   assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
+//   assert(vector.back == "bb", "Incorrect back entry");
+//   assert(vector.last == "bb", "Incorrect last entry");
+//   assert(vector.front == "bb", "Incorrect front entry");
+//   assert(vector.first == "bb", "Incorrect first entry");
+//   assert(vector[0] == "bb", "incorrect vector contents");
+//   assert(_vectorHasContents(vector, ["bb"]), "Unexpected vector contents. Expected [bb]");
 
-  vector.pushBack("bc");
-  assert(vector.length == 2, "Vector has incorrect length");
-  assert(vector.containsIndex(0), "Non empty vector does not have index 0");
-  assert(vector.containsIndex(1), "Vector size 2 does not have index 1");
-  assert(!vector.containsIndex(2), "Vector size 2 incorrectly has index 2");
-  assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
-  assert(_vectorHasContents(vector, ["bb", "bc"]), "Unexpected vector contents. Expected [ba, bb]");
-  vector[1] = "bd";
-  assert(_vectorHasContents(vector, ["bb", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+//   vector.pushBack("bc");
+//   assert(vector.length == 2, "Vector has incorrect length");
+//   assert(vector.containsIndex(0), "Non empty vector does not have index 0");
+//   assert(vector.containsIndex(1), "Vector size 2 does not have index 1");
+//   assert(!vector.containsIndex(2), "Vector size 2 incorrectly has index 2");
+//   assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
+//   assert(_vectorHasContents(vector, ["bb", "bc"]), "Unexpected vector contents. Expected [ba, bb]");
+//   vector[1] = "bd";
+//   assert(_vectorHasContents(vector, ["bb", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
 
-  vector[0] = "aa";
-  assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
-  assert(vector.length == 2, "Vector has incorrect length")
-  vector.pushBack("be");
-  assert(_vectorHasContents(vector, ["aa", "bd", "be"]), "Unexpected vector contents. Expected [aa, bd, be]");
-  assert(vector.length == 3, "Vector has incorrect length")
-  assert(vector.back == "be", "Incorrect back entry")
-  assert(vector.last == "be", "Incorrect last entry")
-  assert(vector.front == "aa", "Incorrect front entry")
-  assert(vector.first == "aa", "Incorrect first entry")
+//   vector[0] = "aa";
+//   assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
+//   assert(vector.length == 2, "Vector has incorrect length")
+//   vector.pushBack("be");
+//   assert(_vectorHasContents(vector, ["aa", "bd", "be"]), "Unexpected vector contents. Expected [aa, bd, be]");
+//   assert(vector.length == 3, "Vector has incorrect length")
+//   assert(vector.back == "be", "Incorrect back entry")
+//   assert(vector.last == "be", "Incorrect last entry")
+//   assert(vector.front == "aa", "Incorrect front entry")
+//   assert(vector.first == "aa", "Incorrect first entry")
 
-  //pop an entry and then try various other methods
-  vector.pop();
-  assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
-  assert(vector.length == 2, "Vector has incorrect length after delete")
-  vector[0] = "ba";
-  assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
-  assert(vector.length == 2, "Vector has incorrect length")
-  vector.pushBack("bf");
-  assert(_vectorHasContents(vector, ["ba", "bd", "bf"]), "Unexpected vector contents. Expected [ba, bd, bf]");
-  assert(vector.length == 3, "Vector has incorrect length")
-  vector.popBack();
-  assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
-  assert(vector.length == 2, "Vector has incorrect length");
+//   //pop an entry and then try various other methods
+//   vector.pop();
+//   assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
+//   assert(vector.length == 2, "Vector has incorrect length after delete")
+//   vector[0] = "ba";
+//   assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+//   assert(vector.length == 2, "Vector has incorrect length")
+//   vector.pushBack("bf");
+//   assert(_vectorHasContents(vector, ["ba", "bd", "bf"]), "Unexpected vector contents. Expected [ba, bd, bf]");
+//   assert(vector.length == 3, "Vector has incorrect length")
+//   vector.popBack();
+//   assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+//   assert(vector.length == 2, "Vector has incorrect length");
 
-  // same id but different object.
-  const vectorReread = new PersistentVector<string>("vector1");
-  assert(vectorReread != null, "Vector not initialized");
-  assert(vectorReread.length == 2, "Vector has incorrect length");
+//   // same id but different object.
+//   const vectorReread = new PersistentVector<string>("vector1");
+//   assert(vectorReread != null, "Vector not initialized");
+//   assert(vectorReread.length == 2, "Vector has incorrect length");
 
-  // vector with primitives
-  const vectorI32 = new PersistentVector<i32>("vectori32");
-  vectorI32.pushBack(2);
-  assert(vectorI32.length == 1, "Vector i32 has incorrect length");
-}
+//   // vector with primitives
+//   const vectorI32 = new PersistentVector<i32>("vectori32");
+//   vectorI32.pushBack(2);
+//   assert(vectorI32.length == 1, "Vector i32 has incorrect length");
+// }
 
-export function dequeTests(): void {
-  logging.log("dequeTests");
-  const deque = new PersistentDeque<string>("dequeid");
+// export function dequeTests(): void {
+//   logging.log("dequeTests");
+//   const deque = new PersistentDeque<string>("dequeid");
 
-  assert(deque.length == 0, "empty deque length is wrong");
-  assert(!deque.containsIndex(0), "empty deque contains index 0");
-  assert(deque.isEmpty == true, "empty deque returns false for isEmpty");
+//   assert(deque.length == 0, "empty deque length is wrong");
+//   assert(!deque.containsIndex(0), "empty deque contains index 0");
+//   assert(deque.isEmpty == true, "empty deque returns false for isEmpty");
 
-  deque.pushBack("1");
-  assert(deque.length == 1, "deque length is wrong");
-  assert(deque.containsIndex(0), "deque does not contain index 0");
-  assert(!deque.containsIndex(-1), "deque does not contain index 0");
-  assert(deque.isEmpty == false, "deque returns true for isEmpty");
-  assert(deque[0] == "1", "wrong element value using []");
-  assert(deque.back == "1", "wrong back element");
-  assert(deque.front == "1", "wrong front element");
-  assert(deque.first == "1", "wrong first element");
-  assert(deque.last == "1", "wrong last element");
+//   deque.pushBack("1");
+//   assert(deque.length == 1, "deque length is wrong");
+//   assert(deque.containsIndex(0), "deque does not contain index 0");
+//   assert(!deque.containsIndex(-1), "deque does not contain index 0");
+//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
+//   assert(deque[0] == "1", "wrong element value using []");
+//   assert(deque.back == "1", "wrong back element");
+//   assert(deque.front == "1", "wrong front element");
+//   assert(deque.first == "1", "wrong first element");
+//   assert(deque.last == "1", "wrong last element");
 
-  deque.pushFront("-2");
-  assert(deque.length == 2, "deque length is wrong");
-  assert(deque.containsIndex(0), "deque does not contain index 0");
-  assert(deque.containsIndex(1), "deque does not contain index 1");
-  assert(deque.isEmpty == false, "deque returns true for isEmpty");
-  assert(deque[1] == "1", "wrong element value using []");
-  assert(deque[0] == "-2", "wrong element value using []");
-  assert(deque.back == "1", "wrong back element");
-  assert(deque.front == "-2", "wrong front element");
-  assert(deque.first == "-2", "wrong first element");
-  assert(deque.last == "1", "wrong last element");
+//   deque.pushFront("-2");
+//   assert(deque.length == 2, "deque length is wrong");
+//   assert(deque.containsIndex(0), "deque does not contain index 0");
+//   assert(deque.containsIndex(1), "deque does not contain index 1");
+//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
+//   assert(deque[1] == "1", "wrong element value using []");
+//   assert(deque[0] == "-2", "wrong element value using []");
+//   assert(deque.back == "1", "wrong back element");
+//   assert(deque.front == "-2", "wrong front element");
+//   assert(deque.first == "-2", "wrong first element");
+//   assert(deque.last == "1", "wrong last element");
 
-  deque.popFront();
-  assert(deque.length == 1, "deque length is wrong");
-  assert(deque.containsIndex(0), "deque does not contain index 0");
-  assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
-  assert(deque.isEmpty == false, "deque returns true for isEmpty");
-  assert(deque[0] == "1", "wrong element value using []");
-  assert(deque.back == "1", "wrong back element");
-  assert(deque.front == "1", "wrong front element");
-  assert(deque.first == "1", "wrong first element");
-  assert(deque.last == "1", "wrong last element");
+//   deque.popFront();
+//   assert(deque.length == 1, "deque length is wrong");
+//   assert(deque.containsIndex(0), "deque does not contain index 0");
+//   assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
+//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
+//   assert(deque[0] == "1", "wrong element value using []");
+//   assert(deque.back == "1", "wrong back element");
+//   assert(deque.front == "1", "wrong front element");
+//   assert(deque.first == "1", "wrong first element");
+//   assert(deque.last == "1", "wrong last element");
 
-  deque.pushFront("-2");
-  deque.popBack();
-  assert(deque.length == 1, "deque length is wrong");
-  assert(deque.containsIndex(0), "deque does not contain index 0");
-  assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
-  assert(deque.isEmpty == false, "deque returns true for isEmpty");
-  assert(deque[0] == "-2", "wrong element value using []");
-  assert(deque.back == "-2", "wrong back element");
-  assert(deque.front == "-2", "wrong front element");
-  assert(deque.first == "-2", "wrong first element");
-  assert(deque.last == "-2", "wrong last element");
-}
+//   deque.pushFront("-2");
+//   deque.popBack();
+//   assert(deque.length == 1, "deque length is wrong");
+//   assert(deque.containsIndex(0), "deque does not contain index 0");
+//   assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
+//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
+//   assert(deque[0] == "-2", "wrong element value using []");
+//   assert(deque.back == "-2", "wrong back element");
+//   assert(deque.front == "-2", "wrong front element");
+//   assert(deque.first == "-2", "wrong first element");
+//   assert(deque.last == "-2", "wrong last element");
+// }
 
-export function topnTests(): void {
-  logging.log("topnTests");
-  // empty topn cases
-  const topn = new PersistentTopN<string>("topnid");
-  assert(topn != null, "topn is null");
-  assert(topn.isEmpty, "empty topn - wrong result for isEmpty");
-  assert(topn.length == 0, "empty topn - wrong length");
-  assert(!topn.contains("nonexistentKey"), "empty topn - contains nonexistent key");
-  topn.delete("nonexistentKey"); // this should not crash
-  assert(topn.keysToRatings(new Array<string>(0)).length == 0, "keys to ratings for empty topn is not empty");
-  assert(topn.getTop(10).length == 0, "get top for empty topn returned non empty list")
-  //assert(topn.getTopFromKey(10, "somekey").length == 0, "getTopFromKey for empty topn returned non empty list") // fails due to key doesn't exist
-  assert(topn.getTopWithRating(10).length == 0, "getTopWithRating for empty topn is not empty");
-  //assert(topn.getTopWithRatingFromKey(10, "somekey").length == 0, "getTopWithRatingFromKey for empty topn is not empty"); // fails due to key doesn't exist
+// export function topnTests(): void {
+//   logging.log("topnTests");
+//   // empty topn cases
+//   const topn = new PersistentTopN<string>("topnid");
+//   assert(topn != null, "topn is null");
+//   assert(topn.isEmpty, "empty topn - wrong result for isEmpty");
+//   assert(topn.length == 0, "empty topn - wrong length");
+//   assert(!topn.contains("nonexistentKey"), "empty topn - contains nonexistent key");
+//   topn.delete("nonexistentKey"); // this should not crash
+//   assert(topn.keysToRatings(new Array<string>(0)).length == 0, "keys to ratings for empty topn is not empty");
+//   assert(topn.getTop(10).length == 0, "get top for empty topn returned non empty list")
+//   //assert(topn.getTopFromKey(10, "somekey").length == 0, "getTopFromKey for empty topn returned non empty list") // fails due to key doesn't exist
+//   assert(topn.getTopWithRating(10).length == 0, "getTopWithRating for empty topn is not empty");
+//   //assert(topn.getTopWithRatingFromKey(10, "somekey").length == 0, "getTopWithRatingFromKey for empty topn is not empty"); // fails due to key doesn't exist
 
-  topn.setRating("k1", 5);
-  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-  assert(topn.length == 1, "topn - wrong length");
-  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-  assert(topn.contains("k1"), "topn - does not contain a key that should be there");
-  topn.delete("nonexistentKey"); // this should not crash
-  assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
-  assert(topn.keysToRatings(["k1"])[0].value == 5, "keys to ratings wrong for topn");
-  assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
-  assert(topn.getTop(10)[0] == "k1", "wrong key in getTop")
-  assert(topn.getTopFromKey(10, "k1").length == 0, "getTopFromKey for topn wrong result");
-  assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
-  assert(topn.getTopWithRatingFromKey(10, "k1").length == 0, "getTopWithRatingFromKey for topn is not empty");
+//   topn.setRating("k1", 5);
+//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+//   assert(topn.length == 1, "topn - wrong length");
+//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+//   assert(topn.contains("k1"), "topn - does not contain a key that should be there");
+//   topn.delete("nonexistentKey"); // this should not crash
+//   assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
+//   assert(topn.keysToRatings(["k1"])[0].value == 5, "keys to ratings wrong for topn");
+//   assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
+//   assert(topn.getTop(10)[0] == "k1", "wrong key in getTop")
+//   assert(topn.getTopFromKey(10, "k1").length == 0, "getTopFromKey for topn wrong result");
+//   assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
+//   assert(topn.getTopWithRatingFromKey(10, "k1").length == 0, "getTopWithRatingFromKey for topn is not empty");
 
-  // Tests with 2 entries --  k1: 6, k: 5
-  topn.setRating("k", 5);
-  topn.incrementRating("k1");
-  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-  assert(topn.length == 2, "topn - wrong length");
-  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-  assert(topn.contains("k"), "topn - does not contain a key that should be there");
-  assert(topn.contains("k1"), "topn - does not contain a key that should be there");
-  topn.delete("nonexistentKey"); // this should not crash
-  assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
-  assert(topn.keysToRatings(["k1", "k"]).length == 2, "keys to ratings wrong for topn");
-  assert(topn.keysToRatings(["k1", "k"])[0].value == 6, "keys to ratings wrong for topn");
-  assert(topn.keysToRatings(["k1", "k"])[1].value == 5, "keys to ratings wrong for topn");
-  assert(topn.getTop(10).length == 2, "get top for topn is wrong");
-  assert(topn.getTop(10)[0] == "k1", "wrong key in getTop");
-  assert(topn.getTop(10)[1] == "k", "wrong key in getTop");
-  assert(topn.getTop(1).length == 1, "get top for topn is wrong when limit is applied");
-  assert(topn.getTop(1)[0] == "k1", "wrong key in getTop");
-  assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
-  assert(topn.getTopFromKey(10, "k1").length == 1, "getTopFromKey for topn wrong result");
-  assert(topn.getTopFromKey(10, "k1")[0] == "k", "getTopFromKey for topn wrong result");
-  assert(topn.getTopWithRating(10).length == 2, "getTopWithRating for topn with 1 element is wrong size");
-  assert(topn.getTopWithRating(10)[0].value == 6, "getTopWithRating for topn with 1 element is wrong size");
-  assert(topn.getTopWithRating(10)[1].value == 5, "getTopWithRating for topn with 1 element is wrong size");
+//   // Tests with 2 entries --  k1: 6, k: 5
+//   topn.setRating("k", 5);
+//   topn.incrementRating("k1");
+//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+//   assert(topn.length == 2, "topn - wrong length");
+//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+//   assert(topn.contains("k"), "topn - does not contain a key that should be there");
+//   assert(topn.contains("k1"), "topn - does not contain a key that should be there");
+//   topn.delete("nonexistentKey"); // this should not crash
+//   assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
+//   assert(topn.keysToRatings(["k1", "k"]).length == 2, "keys to ratings wrong for topn");
+//   assert(topn.keysToRatings(["k1", "k"])[0].value == 6, "keys to ratings wrong for topn");
+//   assert(topn.keysToRatings(["k1", "k"])[1].value == 5, "keys to ratings wrong for topn");
+//   assert(topn.getTop(10).length == 2, "get top for topn is wrong");
+//   assert(topn.getTop(10)[0] == "k1", "wrong key in getTop");
+//   assert(topn.getTop(10)[1] == "k", "wrong key in getTop");
+//   assert(topn.getTop(1).length == 1, "get top for topn is wrong when limit is applied");
+//   assert(topn.getTop(1)[0] == "k1", "wrong key in getTop");
+//   assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
+//   assert(topn.getTopFromKey(10, "k1").length == 1, "getTopFromKey for topn wrong result");
+//   assert(topn.getTopFromKey(10, "k1")[0] == "k", "getTopFromKey for topn wrong result");
+//   assert(topn.getTopWithRating(10).length == 2, "getTopWithRating for topn with 1 element is wrong size");
+//   assert(topn.getTopWithRating(10)[0].value == 6, "getTopWithRating for topn with 1 element is wrong size");
+//   assert(topn.getTopWithRating(10)[1].value == 5, "getTopWithRating for topn with 1 element is wrong size");
 
-  topn.delete("k1");
-  topn.incrementRating("k");
-  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-  assert(topn.length == 1, "topn - wrong length");
-  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-  assert(topn.contains("k"), "topn - does not contain a key that should be there");
-  topn.delete("nonexistentKey"); // this should not crash
-  assert(topn.keysToRatings(["k"]).length == 1, "keys to ratings wrong for topn");
-  assert(topn.keysToRatings(["k"])[0].value == 6, "keys to ratings wrong for topn");
-  assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
-  assert(topn.getTop(10)[0] == "k", "wrong key in getTop")
-  assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
-  assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
-  assert(topn.getTopWithRatingFromKey(10, "k").length == 0, "getTopWithRatingFromKey for topn is not empty");
-}
+//   topn.delete("k1");
+//   topn.incrementRating("k");
+//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+//   assert(topn.length == 1, "topn - wrong length");
+//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+//   assert(topn.contains("k"), "topn - does not contain a key that should be there");
+//   topn.delete("nonexistentKey"); // this should not crash
+//   assert(topn.keysToRatings(["k"]).length == 1, "keys to ratings wrong for topn");
+//   assert(topn.keysToRatings(["k"])[0].value == 6, "keys to ratings wrong for topn");
+//   assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
+//   assert(topn.getTop(10)[0] == "k", "wrong key in getTop")
+//   assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
+//   assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
+//   assert(topn.getTopWithRatingFromKey(10, "k").length == 0, "getTopWithRatingFromKey for topn is not empty");
+// }
 
-export function contextTests(): void {
-  logging.log("contextTests");
-  assert(context.sender == "bob", "Wrong sender");
-  assert(context.contractName == "contractaccount", "Wrong contract name");
-  assert(context.blockIndex == 113, "Wrong contract name");
-  assert(context.attachedDeposit == u128.fromU64(7), "Wrong receivedAmount");
-  assert(context.accountBalance == u128.fromU64(14), "Wrong receivedAmount");
-  assert(context.prepaidGas == 1000000000, "Wrong prepaid gas");
-  assert(context.usedGas <= 1000000000, "Wrong used gas");
-  assert(context.usedGas > 0, "Wrong used gas");
-  //assert(context.storageUsage == 0, "Wrong storage usage"); TODO: test when implemented
-}
+// export function contextTests(): void {
+//   logging.log("contextTests");
+//   assert(context.sender == "bob", "Wrong sender");
+//   assert(context.contractName == "contractaccount", "Wrong contract name");
+//   assert(context.blockIndex == 113, "Wrong contract name");
+//   assert(context.attachedDeposit == u128.fromU64(7), "Wrong receivedAmount");
+//   assert(context.accountBalance == u128.fromU64(14), "Wrong receivedAmount");
+//   assert(context.prepaidGas == 1000000000, "Wrong prepaid gas");
+//   assert(context.usedGas <= 1000000000, "Wrong used gas");
+//   assert(context.usedGas > 0, "Wrong used gas");
+//   //assert(context.storageUsage == 0, "Wrong storage usage"); TODO: test when implemented
+// }
 
-export function promiseTests(): void {
-  logging.log("promiseTests");
-  const emptyResults = ContractPromise.getResults();
-  assert(emptyResults.length == 0, "wrong length for results");
-  const promise = ContractPromise.create("contractNameForPromise", "methodName", new Uint8Array(0), 100);
-  const promise2 = promise.then("contractNameForPromise", "methodName", new Uint8Array(0), 100);
-  const promise3 = ContractPromise.all([promise2]);
-}
+// export function promiseTests(): void {
+//   logging.log("promiseTests");
+//   const emptyResults = ContractPromise.getResults();
+//   assert(emptyResults.length == 0, "wrong length for results");
+//   const promise = ContractPromise.create("contractNameForPromise", "methodName", new Uint8Array(0), 100);
+//   const promise2 = promise.then("contractNameForPromise", "methodName", new Uint8Array(0), 100);
+//   const promise3 = ContractPromise.all([promise2]);
+// }
 
-export function mathTests(): void {
-  logging.log("mathTests");
-  const array = _testBytes();
-  const hash = math.hash32Bytes(array);
-  assert(hash == 3593695342, "wrong hash");
+// export function mathTests(): void {
+//   logging.log("mathTests");
+//   const array = _testBytes();
+//   const hash = math.hash32Bytes(array);
+//   assert(hash == 3593695342, "wrong hash");
 
-  const stringValue = "toHash";
-  const hashOfString = math.hash32(stringValue);
-  assert(hashOfString == 3394043202, "wrong hash of the string");
+//   const stringValue = "toHash";
+//   const hashOfString = math.hash32(stringValue);
+//   assert(hashOfString == 3394043202, "wrong hash of the string");
 
-  const hash256 = math.hash(stringValue);
-  let x: i32[] = [1, 6, 7];
-  assert(hash256.length == 32, "wrong output length for hash256");
-  assert(hash256[0] == 202, "wrong contents of hash256");
-  assert(hash256[1] == 76, "wrong contents of hash256");
-  assert(hash256[31] == 184, "wrong contents of hash256");
-}
+//   const hash256 = math.hash(stringValue);
+//   let x: i32[] = [1, 6, 7];
+//   assert(hash256.length == 32, "wrong output length for hash256");
+//   assert(hash256[0] == 202, "wrong contents of hash256");
+//   assert(hash256[1] == 76, "wrong contents of hash256");
+//   assert(hash256[31] == 184, "wrong contents of hash256");
+// }
 
 
 // cruft to compare test objects. TODO: use something standard

--- a/tests/assembly/main.ts
+++ b/tests/assembly/main.ts
@@ -93,330 +93,330 @@ export function storageGenericGetSetRoundtripTest(): void {
   assert(storage.get<string>("nonexistent", null) == null, "Incorrect data value for get<T> string nonexistent key");
 }
 
-// export function storageKeysTest(): string[] {
-//   logging.log("storageKeysTest");
+export function storageKeysTest(): string[] {
+  logging.log("storageKeysTest");
 
-//   // empty storage
-//   const emptyKeys = storage.keys("someKey");
-//   assert(emptyKeys.length == 0, "Incorrect keys contents for empty storage");
+  // empty storage
+  const emptyKeys = storage.keys("someKey");
+  assert(emptyKeys.length == 0, "Incorrect keys contents for empty storage");
 
-//   // add some keys
-//   storage.setString("someApple", "myApple");
-//   storage.setString("someKey", "myValue1");
-//   storage.setString("someKey2", "myValue1");
-//   storage.setString("someKey6", "myValue2");
+  // add some keys
+  storage.setString("someApple", "myApple");
+  storage.setString("someKey", "myValue1");
+  storage.setString("someKey2", "myValue1");
+  storage.setString("someKey6", "myValue2");
 
-//   const keyRange = storage.keyRange("someKey", "someKey3");
-//   assert(keyRange.length == 2, "Incorrect keys length");
-//   assert(keyRange[0] == "someKey", "Incorrect keys contents");
-//   assert(keyRange[1] == "someKey2", "Incorrect keys contents");
-//   const keyRangeWithLimit = storage.keyRange("someKey", "someKey3", 1);
-//   assert(keyRangeWithLimit.length == 1, "Incorrect keys length");
-//   assert(keyRangeWithLimit[0] == "someKey", "Incorrect keys contents");
+  const keyRange = storage.keyRange("someKey", "someKey3");
+  assert(keyRange.length == 2, "Incorrect keys length");
+  assert(keyRange[0] == "someKey", "Incorrect keys contents");
+  assert(keyRange[1] == "someKey2", "Incorrect keys contents");
+  const keyRangeWithLimit = storage.keyRange("someKey", "someKey3", 1);
+  assert(keyRangeWithLimit.length == 1, "Incorrect keys length");
+  assert(keyRangeWithLimit[0] == "someKey", "Incorrect keys contents");
 
-//   const keys = storage.keys("someKey");
-//   assert(keys.length == 3, "Incorrect keys length");
-//   assert(keys[0] == "someKey", "Incorrect keys contents");
-//   assert(keys[1] == "someKey2", "Incorrect keys contents");
-//   assert(keys[2] == "someKey6", "Incorrect keys contents");
-//   const keysWithLimit = storage.keys("someKey", 1);
-//   assert(keysWithLimit.length == 1, "Incorrect keys length");
-//   assert(keys[0] == "someKey", "Incorrect keys contents")
+  const keys = storage.keys("someKey");
+  assert(keys.length == 3, "Incorrect keys length");
+  assert(keys[0] == "someKey", "Incorrect keys contents");
+  assert(keys[1] == "someKey2", "Incorrect keys contents");
+  assert(keys[2] == "someKey6", "Incorrect keys contents");
+  const keysWithLimit = storage.keys("someKey", 1);
+  assert(keysWithLimit.length == 1, "Incorrect keys length");
+  assert(keys[0] == "someKey", "Incorrect keys contents")
 
-//   assert(storage.contains("someApple"), "Storage does not contain key");
-//   assert(storage.contains("someKey"), "Storage does not contain key");
-//   assert(storage.contains("someKey2"), "Storage does not contain key");
-//   assert(storage.contains("someKey6"), "Storage does not contain key");
-//   assert(!storage.contains("nonexisting"), "Storage has unexpected key");
-//   assert(storage.hasKey("someKey6"), "Storage does not contain key");
-//   assert(!storage.hasKey("nonexisting"), "Storage has unexpected key");
+  assert(storage.contains("someApple"), "Storage does not contain key");
+  assert(storage.contains("someKey"), "Storage does not contain key");
+  assert(storage.contains("someKey2"), "Storage does not contain key");
+  assert(storage.contains("someKey6"), "Storage does not contain key");
+  assert(!storage.contains("nonexisting"), "Storage has unexpected key");
+  assert(storage.hasKey("someKey6"), "Storage does not contain key");
+  assert(!storage.hasKey("nonexisting"), "Storage has unexpected key");
 
-//   // remove a key and retry some of the api calls
-//   storage.delete("someKey");
-//   assert(!storage.contains("someKey"), "Storage contains key that was deleted");
-//   assert(storage.contains("someKey2"), "Some other key got deleted");
-//   const keyswithdelete = storage.keys("someKey");
-//   assert(keyswithdelete.length == 2, "Incorrect keys length after removing a key")
-//   assert(keyswithdelete[0] == "someKey2", "Incorrect keyswithdelete contents");
-//   assert(keyswithdelete[1] == "someKey6", "Incorrect keyswithdelete contents");
-//   return keyswithdelete;
-// }
+  // remove a key and retry some of the api calls
+  storage.delete("someKey");
+  assert(!storage.contains("someKey"), "Storage contains key that was deleted");
+  assert(storage.contains("someKey2"), "Some other key got deleted");
+  const keyswithdelete = storage.keys("someKey");
+  assert(keyswithdelete.length == 2, "Incorrect keys length after removing a key")
+  assert(keyswithdelete[0] == "someKey2", "Incorrect keyswithdelete contents");
+  assert(keyswithdelete[1] == "someKey6", "Incorrect keyswithdelete contents");
+  return keyswithdelete;
+}
 
-// export function mapTests(): void {
-//   logging.log("mapTests");
-//   // empty map
-//   const map = new PersistentMap<string, TextMessage>("mapId");
-//   const valuesEmpty = map.values("", "zzz");
-//   assert(valuesEmpty.length == 0, "Unexpected values in empty map");
-//   assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
-//   assert(map.get("nonexistentkey") == null, "Incorrect result on get with nonexistent key");
+export function mapTests(): void {
+  logging.log("mapTests");
+  // empty map
+  const map = new PersistentMap<string, TextMessage>("mapId");
+  const valuesEmpty = map.values("", "zzz");
+  assert(valuesEmpty.length == 0, "Unexpected values in empty map");
+  assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
+  assert(map.get("nonexistentkey") == null, "Incorrect result on get with nonexistent key");
 
-//   // add some entries to the map
-//   const message = _testTextMessage();
-//   map.set("mapKey1", message);
-//   map.set("mapKey3", _testTextMessageTwo());
-//   const values = map.values("", "zzz");
-//   assert(values.length == 2, "Unexpected values size in map with 2 entries");
-//   assert(_modelObjectEqual(values[0], message), "Unexpected values contents in map with 2 entries");
-//   assert(_modelObjectEqual(values[1], _testTextMessageTwo()), "Unexpected values contents in map with 2 entries");
-//   assert(map.values("mapKey3", "zzz").length == 1, "Unexpected values size in map with 2 entries");
-//   assert(map.values("mapKey1", "mapKey2").length == 1, "Unexpected values size in map with 2 entries");
-//   assert(map.values("mapKey1", "mapKey4", -1, false).length == 1, "Unexpected values size in map with 2 entries");
-//   assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
-//   assert(map.contains("mapKey1"), "Map does not contain a key that was added (mapKey1)");
-//   assert(map.contains("mapKey3"), "Map does not contain a key that was added (mapKey3)");
-//   assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get");
-//   assert(_modelObjectEqual(map.get("mapKey3"), _testTextMessageTwo()), "Incorrect result from map get");
+  // add some entries to the map
+  const message = _testTextMessage();
+  map.set("mapKey1", message);
+  map.set("mapKey3", _testTextMessageTwo());
+  const values = map.values("", "zzz");
+  assert(values.length == 2, "Unexpected values size in map with 2 entries");
+  assert(_modelObjectEqual(values[0], message), "Unexpected values contents in map with 2 entries");
+  assert(_modelObjectEqual(values[1], _testTextMessageTwo()), "Unexpected values contents in map with 2 entries");
+  assert(map.values("mapKey3", "zzz").length == 1, "Unexpected values size in map with 2 entries");
+  assert(map.values("mapKey1", "mapKey2").length == 1, "Unexpected values size in map with 2 entries");
+  assert(map.values("mapKey1", "mapKey4", -1, false).length == 1, "Unexpected values size in map with 2 entries");
+  assert(!map.contains("nonexistentkey"), "Map contains a non existent key");
+  assert(map.contains("mapKey1"), "Map does not contain a key that was added (mapKey1)");
+  assert(map.contains("mapKey3"), "Map does not contain a key that was added (mapKey3)");
+  assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get");
+  assert(_modelObjectEqual(map.get("mapKey3"), _testTextMessageTwo()), "Incorrect result from map get");
 
-//   // delete an entry and retry api calls
-//   map.delete("mapKey3");
-//   assert(map.values("", "zzz").length == 1, "Unexpected values size in map after delete");
-//   assert(_modelObjectEqual(map.values("", "zzz")[0], message), "Unexpected values contents in map after delete");
-//   assert(map.values("mapKey1", "zzz").length == 1, "Unexpected values size in map after delete");
-//   assert(!map.contains("mapKey3"), "Map contains a key that was deleted");
-//   assert(map.contains("mapKey1"), "Map does not contain a key that should be there after deletion of another key");
-//   assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get after delete");
-//   assert(map.get("mapKey3") == null, "Incorrect result from map get on a deleted key");
-// }
+  // delete an entry and retry api calls
+  map.delete("mapKey3");
+  assert(map.values("", "zzz").length == 1, "Unexpected values size in map after delete");
+  assert(_modelObjectEqual(map.values("", "zzz")[0], message), "Unexpected values contents in map after delete");
+  assert(map.values("mapKey1", "zzz").length == 1, "Unexpected values size in map after delete");
+  assert(!map.contains("mapKey3"), "Map contains a key that was deleted");
+  assert(map.contains("mapKey1"), "Map does not contain a key that should be there after deletion of another key");
+  assert(_modelObjectEqual(map.get("mapKey1"), message), "Incorrect result from map get after delete");
+  assert(map.get("mapKey3") == null, "Incorrect result from map get on a deleted key");
+}
 
-// export function mapTestsWithPrimitices(): void{
-//   // map with primitives
-//   const map = new PersistentMap<i32, i32>("mapPrimitives");
-//   map.set(1, -20);
-//   assert(map.getSome(1) == -20, "wrong value on map get for i32");
-// }
+export function mapTestsWithPrimitices(): void{
+  // map with primitives
+  const map = new PersistentMap<i32, i32>("mapPrimitives");
+  map.set(1, -20);
+  assert(map.getSome(1) == -20, "wrong value on map get for i32");
+}
 
-// export function vectorTests(): void {
-//   logging.log("vectorTests");
-//   const vector = new PersistentVector<string>("vector1");
-//   assert(vector != null, "Vector not initialized");
-//   assert(vector.length == 0, "Empty vector has incorrect length");
-//   assert(!vector.containsIndex(0), "Empty vector incorrectly has index 0");
-//   assert(vector.isEmpty, "isEmpty incorrect on empty vector");
-//   //try { assert(vector[0] == null, "");} catch (e) {} not possible to test due to lack of try catch
+export function vectorTests(): void {
+  logging.log("vectorTests");
+  const vector = new PersistentVector<string>("vector1");
+  assert(vector != null, "Vector not initialized");
+  assert(vector.length == 0, "Empty vector has incorrect length");
+  assert(!vector.containsIndex(0), "Empty vector incorrectly has index 0");
+  assert(vector.isEmpty, "isEmpty incorrect on empty vector");
+  //try { assert(vector[0] == null, "");} catch (e) {} not possible to test due to lack of try catch
 
-//   vector.push("bb");
-//   assert(vector.length == 1, "Vector has incorrect length");
-//   assert(vector.containsIndex(0), "Non empty vector does not have index 0");
-//   assert(!vector.containsIndex(1), "Vector size 1 incorrectly has index 1");
-//   assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
-//   assert(vector.back == "bb", "Incorrect back entry");
-//   assert(vector.last == "bb", "Incorrect last entry");
-//   assert(vector.front == "bb", "Incorrect front entry");
-//   assert(vector.first == "bb", "Incorrect first entry");
-//   assert(vector[0] == "bb", "incorrect vector contents");
-//   assert(_vectorHasContents(vector, ["bb"]), "Unexpected vector contents. Expected [bb]");
+  vector.push("bb");
+  assert(vector.length == 1, "Vector has incorrect length");
+  assert(vector.containsIndex(0), "Non empty vector does not have index 0");
+  assert(!vector.containsIndex(1), "Vector size 1 incorrectly has index 1");
+  assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
+  assert(vector.back == "bb", "Incorrect back entry");
+  assert(vector.last == "bb", "Incorrect last entry");
+  assert(vector.front == "bb", "Incorrect front entry");
+  assert(vector.first == "bb", "Incorrect first entry");
+  assert(vector[0] == "bb", "incorrect vector contents");
+  assert(_vectorHasContents(vector, ["bb"]), "Unexpected vector contents. Expected [bb]");
 
-//   vector.pushBack("bc");
-//   assert(vector.length == 2, "Vector has incorrect length");
-//   assert(vector.containsIndex(0), "Non empty vector does not have index 0");
-//   assert(vector.containsIndex(1), "Vector size 2 does not have index 1");
-//   assert(!vector.containsIndex(2), "Vector size 2 incorrectly has index 2");
-//   assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
-//   assert(_vectorHasContents(vector, ["bb", "bc"]), "Unexpected vector contents. Expected [ba, bb]");
-//   vector[1] = "bd";
-//   assert(_vectorHasContents(vector, ["bb", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+  vector.pushBack("bc");
+  assert(vector.length == 2, "Vector has incorrect length");
+  assert(vector.containsIndex(0), "Non empty vector does not have index 0");
+  assert(vector.containsIndex(1), "Vector size 2 does not have index 1");
+  assert(!vector.containsIndex(2), "Vector size 2 incorrectly has index 2");
+  assert(!vector.isEmpty, "isEmpty incorrect on non-empty vector");
+  assert(_vectorHasContents(vector, ["bb", "bc"]), "Unexpected vector contents. Expected [ba, bb]");
+  vector[1] = "bd";
+  assert(_vectorHasContents(vector, ["bb", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
 
-//   vector[0] = "aa";
-//   assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
-//   assert(vector.length == 2, "Vector has incorrect length")
-//   vector.pushBack("be");
-//   assert(_vectorHasContents(vector, ["aa", "bd", "be"]), "Unexpected vector contents. Expected [aa, bd, be]");
-//   assert(vector.length == 3, "Vector has incorrect length")
-//   assert(vector.back == "be", "Incorrect back entry")
-//   assert(vector.last == "be", "Incorrect last entry")
-//   assert(vector.front == "aa", "Incorrect front entry")
-//   assert(vector.first == "aa", "Incorrect first entry")
+  vector[0] = "aa";
+  assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
+  assert(vector.length == 2, "Vector has incorrect length")
+  vector.pushBack("be");
+  assert(_vectorHasContents(vector, ["aa", "bd", "be"]), "Unexpected vector contents. Expected [aa, bd, be]");
+  assert(vector.length == 3, "Vector has incorrect length")
+  assert(vector.back == "be", "Incorrect back entry")
+  assert(vector.last == "be", "Incorrect last entry")
+  assert(vector.front == "aa", "Incorrect front entry")
+  assert(vector.first == "aa", "Incorrect first entry")
 
-//   //pop an entry and then try various other methods
-//   vector.pop();
-//   assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
-//   assert(vector.length == 2, "Vector has incorrect length after delete")
-//   vector[0] = "ba";
-//   assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
-//   assert(vector.length == 2, "Vector has incorrect length")
-//   vector.pushBack("bf");
-//   assert(_vectorHasContents(vector, ["ba", "bd", "bf"]), "Unexpected vector contents. Expected [ba, bd, bf]");
-//   assert(vector.length == 3, "Vector has incorrect length")
-//   vector.popBack();
-//   assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
-//   assert(vector.length == 2, "Vector has incorrect length");
+  //pop an entry and then try various other methods
+  vector.pop();
+  assert(_vectorHasContents(vector, ["aa", "bd"]), "Unexpected vector contents. Expected [aa, bd]");
+  assert(vector.length == 2, "Vector has incorrect length after delete")
+  vector[0] = "ba";
+  assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+  assert(vector.length == 2, "Vector has incorrect length")
+  vector.pushBack("bf");
+  assert(_vectorHasContents(vector, ["ba", "bd", "bf"]), "Unexpected vector contents. Expected [ba, bd, bf]");
+  assert(vector.length == 3, "Vector has incorrect length")
+  vector.popBack();
+  assert(_vectorHasContents(vector, ["ba", "bd"]), "Unexpected vector contents. Expected [ba, bd]");
+  assert(vector.length == 2, "Vector has incorrect length");
 
-//   // same id but different object.
-//   const vectorReread = new PersistentVector<string>("vector1");
-//   assert(vectorReread != null, "Vector not initialized");
-//   assert(vectorReread.length == 2, "Vector has incorrect length");
+  // same id but different object.
+  const vectorReread = new PersistentVector<string>("vector1");
+  assert(vectorReread != null, "Vector not initialized");
+  assert(vectorReread.length == 2, "Vector has incorrect length");
 
-//   // vector with primitives
-//   const vectorI32 = new PersistentVector<i32>("vectori32");
-//   vectorI32.pushBack(2);
-//   assert(vectorI32.length == 1, "Vector i32 has incorrect length");
-// }
+  // vector with primitives
+  const vectorI32 = new PersistentVector<i32>("vectori32");
+  vectorI32.pushBack(2);
+  assert(vectorI32.length == 1, "Vector i32 has incorrect length");
+}
 
-// export function dequeTests(): void {
-//   logging.log("dequeTests");
-//   const deque = new PersistentDeque<string>("dequeid");
+export function dequeTests(): void {
+  logging.log("dequeTests");
+  const deque = new PersistentDeque<string>("dequeid");
 
-//   assert(deque.length == 0, "empty deque length is wrong");
-//   assert(!deque.containsIndex(0), "empty deque contains index 0");
-//   assert(deque.isEmpty == true, "empty deque returns false for isEmpty");
+  assert(deque.length == 0, "empty deque length is wrong");
+  assert(!deque.containsIndex(0), "empty deque contains index 0");
+  assert(deque.isEmpty == true, "empty deque returns false for isEmpty");
 
-//   deque.pushBack("1");
-//   assert(deque.length == 1, "deque length is wrong");
-//   assert(deque.containsIndex(0), "deque does not contain index 0");
-//   assert(!deque.containsIndex(-1), "deque does not contain index 0");
-//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
-//   assert(deque[0] == "1", "wrong element value using []");
-//   assert(deque.back == "1", "wrong back element");
-//   assert(deque.front == "1", "wrong front element");
-//   assert(deque.first == "1", "wrong first element");
-//   assert(deque.last == "1", "wrong last element");
+  deque.pushBack("1");
+  assert(deque.length == 1, "deque length is wrong");
+  assert(deque.containsIndex(0), "deque does not contain index 0");
+  assert(!deque.containsIndex(-1), "deque does not contain index 0");
+  assert(deque.isEmpty == false, "deque returns true for isEmpty");
+  assert(deque[0] == "1", "wrong element value using []");
+  assert(deque.back == "1", "wrong back element");
+  assert(deque.front == "1", "wrong front element");
+  assert(deque.first == "1", "wrong first element");
+  assert(deque.last == "1", "wrong last element");
 
-//   deque.pushFront("-2");
-//   assert(deque.length == 2, "deque length is wrong");
-//   assert(deque.containsIndex(0), "deque does not contain index 0");
-//   assert(deque.containsIndex(1), "deque does not contain index 1");
-//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
-//   assert(deque[1] == "1", "wrong element value using []");
-//   assert(deque[0] == "-2", "wrong element value using []");
-//   assert(deque.back == "1", "wrong back element");
-//   assert(deque.front == "-2", "wrong front element");
-//   assert(deque.first == "-2", "wrong first element");
-//   assert(deque.last == "1", "wrong last element");
+  deque.pushFront("-2");
+  assert(deque.length == 2, "deque length is wrong");
+  assert(deque.containsIndex(0), "deque does not contain index 0");
+  assert(deque.containsIndex(1), "deque does not contain index 1");
+  assert(deque.isEmpty == false, "deque returns true for isEmpty");
+  assert(deque[1] == "1", "wrong element value using []");
+  assert(deque[0] == "-2", "wrong element value using []");
+  assert(deque.back == "1", "wrong back element");
+  assert(deque.front == "-2", "wrong front element");
+  assert(deque.first == "-2", "wrong first element");
+  assert(deque.last == "1", "wrong last element");
 
-//   deque.popFront();
-//   assert(deque.length == 1, "deque length is wrong");
-//   assert(deque.containsIndex(0), "deque does not contain index 0");
-//   assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
-//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
-//   assert(deque[0] == "1", "wrong element value using []");
-//   assert(deque.back == "1", "wrong back element");
-//   assert(deque.front == "1", "wrong front element");
-//   assert(deque.first == "1", "wrong first element");
-//   assert(deque.last == "1", "wrong last element");
+  deque.popFront();
+  assert(deque.length == 1, "deque length is wrong");
+  assert(deque.containsIndex(0), "deque does not contain index 0");
+  assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
+  assert(deque.isEmpty == false, "deque returns true for isEmpty");
+  assert(deque[0] == "1", "wrong element value using []");
+  assert(deque.back == "1", "wrong back element");
+  assert(deque.front == "1", "wrong front element");
+  assert(deque.first == "1", "wrong first element");
+  assert(deque.last == "1", "wrong last element");
 
-//   deque.pushFront("-2");
-//   deque.popBack();
-//   assert(deque.length == 1, "deque length is wrong");
-//   assert(deque.containsIndex(0), "deque does not contain index 0");
-//   assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
-//   assert(deque.isEmpty == false, "deque returns true for isEmpty");
-//   assert(deque[0] == "-2", "wrong element value using []");
-//   assert(deque.back == "-2", "wrong back element");
-//   assert(deque.front == "-2", "wrong front element");
-//   assert(deque.first == "-2", "wrong first element");
-//   assert(deque.last == "-2", "wrong last element");
-// }
+  deque.pushFront("-2");
+  deque.popBack();
+  assert(deque.length == 1, "deque length is wrong");
+  assert(deque.containsIndex(0), "deque does not contain index 0");
+  assert(!deque.containsIndex(1), "deque of length 1 contains index 1");
+  assert(deque.isEmpty == false, "deque returns true for isEmpty");
+  assert(deque[0] == "-2", "wrong element value using []");
+  assert(deque.back == "-2", "wrong back element");
+  assert(deque.front == "-2", "wrong front element");
+  assert(deque.first == "-2", "wrong first element");
+  assert(deque.last == "-2", "wrong last element");
+}
 
-// export function topnTests(): void {
-//   logging.log("topnTests");
-//   // empty topn cases
-//   const topn = new PersistentTopN<string>("topnid");
-//   assert(topn != null, "topn is null");
-//   assert(topn.isEmpty, "empty topn - wrong result for isEmpty");
-//   assert(topn.length == 0, "empty topn - wrong length");
-//   assert(!topn.contains("nonexistentKey"), "empty topn - contains nonexistent key");
-//   topn.delete("nonexistentKey"); // this should not crash
-//   assert(topn.keysToRatings(new Array<string>(0)).length == 0, "keys to ratings for empty topn is not empty");
-//   assert(topn.getTop(10).length == 0, "get top for empty topn returned non empty list")
-//   //assert(topn.getTopFromKey(10, "somekey").length == 0, "getTopFromKey for empty topn returned non empty list") // fails due to key doesn't exist
-//   assert(topn.getTopWithRating(10).length == 0, "getTopWithRating for empty topn is not empty");
-//   //assert(topn.getTopWithRatingFromKey(10, "somekey").length == 0, "getTopWithRatingFromKey for empty topn is not empty"); // fails due to key doesn't exist
+export function topnTests(): void {
+  logging.log("topnTests");
+  // empty topn cases
+  const topn = new PersistentTopN<string>("topnid");
+  assert(topn != null, "topn is null");
+  assert(topn.isEmpty, "empty topn - wrong result for isEmpty");
+  assert(topn.length == 0, "empty topn - wrong length");
+  assert(!topn.contains("nonexistentKey"), "empty topn - contains nonexistent key");
+  topn.delete("nonexistentKey"); // this should not crash
+  assert(topn.keysToRatings(new Array<string>(0)).length == 0, "keys to ratings for empty topn is not empty");
+  assert(topn.getTop(10).length == 0, "get top for empty topn returned non empty list")
+  //assert(topn.getTopFromKey(10, "somekey").length == 0, "getTopFromKey for empty topn returned non empty list") // fails due to key doesn't exist
+  assert(topn.getTopWithRating(10).length == 0, "getTopWithRating for empty topn is not empty");
+  //assert(topn.getTopWithRatingFromKey(10, "somekey").length == 0, "getTopWithRatingFromKey for empty topn is not empty"); // fails due to key doesn't exist
 
-//   topn.setRating("k1", 5);
-//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-//   assert(topn.length == 1, "topn - wrong length");
-//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-//   assert(topn.contains("k1"), "topn - does not contain a key that should be there");
-//   topn.delete("nonexistentKey"); // this should not crash
-//   assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
-//   assert(topn.keysToRatings(["k1"])[0].value == 5, "keys to ratings wrong for topn");
-//   assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
-//   assert(topn.getTop(10)[0] == "k1", "wrong key in getTop")
-//   assert(topn.getTopFromKey(10, "k1").length == 0, "getTopFromKey for topn wrong result");
-//   assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
-//   assert(topn.getTopWithRatingFromKey(10, "k1").length == 0, "getTopWithRatingFromKey for topn is not empty");
+  topn.setRating("k1", 5);
+  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+  assert(topn.length == 1, "topn - wrong length");
+  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+  assert(topn.contains("k1"), "topn - does not contain a key that should be there");
+  topn.delete("nonexistentKey"); // this should not crash
+  assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
+  assert(topn.keysToRatings(["k1"])[0].value == 5, "keys to ratings wrong for topn");
+  assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
+  assert(topn.getTop(10)[0] == "k1", "wrong key in getTop")
+  assert(topn.getTopFromKey(10, "k1").length == 0, "getTopFromKey for topn wrong result");
+  assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
+  assert(topn.getTopWithRatingFromKey(10, "k1").length == 0, "getTopWithRatingFromKey for topn is not empty");
 
-//   // Tests with 2 entries --  k1: 6, k: 5
-//   topn.setRating("k", 5);
-//   topn.incrementRating("k1");
-//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-//   assert(topn.length == 2, "topn - wrong length");
-//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-//   assert(topn.contains("k"), "topn - does not contain a key that should be there");
-//   assert(topn.contains("k1"), "topn - does not contain a key that should be there");
-//   topn.delete("nonexistentKey"); // this should not crash
-//   assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
-//   assert(topn.keysToRatings(["k1", "k"]).length == 2, "keys to ratings wrong for topn");
-//   assert(topn.keysToRatings(["k1", "k"])[0].value == 6, "keys to ratings wrong for topn");
-//   assert(topn.keysToRatings(["k1", "k"])[1].value == 5, "keys to ratings wrong for topn");
-//   assert(topn.getTop(10).length == 2, "get top for topn is wrong");
-//   assert(topn.getTop(10)[0] == "k1", "wrong key in getTop");
-//   assert(topn.getTop(10)[1] == "k", "wrong key in getTop");
-//   assert(topn.getTop(1).length == 1, "get top for topn is wrong when limit is applied");
-//   assert(topn.getTop(1)[0] == "k1", "wrong key in getTop");
-//   assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
-//   assert(topn.getTopFromKey(10, "k1").length == 1, "getTopFromKey for topn wrong result");
-//   assert(topn.getTopFromKey(10, "k1")[0] == "k", "getTopFromKey for topn wrong result");
-//   assert(topn.getTopWithRating(10).length == 2, "getTopWithRating for topn with 1 element is wrong size");
-//   assert(topn.getTopWithRating(10)[0].value == 6, "getTopWithRating for topn with 1 element is wrong size");
-//   assert(topn.getTopWithRating(10)[1].value == 5, "getTopWithRating for topn with 1 element is wrong size");
+  // Tests with 2 entries --  k1: 6, k: 5
+  topn.setRating("k", 5);
+  topn.incrementRating("k1");
+  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+  assert(topn.length == 2, "topn - wrong length");
+  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+  assert(topn.contains("k"), "topn - does not contain a key that should be there");
+  assert(topn.contains("k1"), "topn - does not contain a key that should be there");
+  topn.delete("nonexistentKey"); // this should not crash
+  assert(topn.keysToRatings(["k1"]).length == 1, "keys to ratings wrong for topn");
+  assert(topn.keysToRatings(["k1", "k"]).length == 2, "keys to ratings wrong for topn");
+  assert(topn.keysToRatings(["k1", "k"])[0].value == 6, "keys to ratings wrong for topn");
+  assert(topn.keysToRatings(["k1", "k"])[1].value == 5, "keys to ratings wrong for topn");
+  assert(topn.getTop(10).length == 2, "get top for topn is wrong");
+  assert(topn.getTop(10)[0] == "k1", "wrong key in getTop");
+  assert(topn.getTop(10)[1] == "k", "wrong key in getTop");
+  assert(topn.getTop(1).length == 1, "get top for topn is wrong when limit is applied");
+  assert(topn.getTop(1)[0] == "k1", "wrong key in getTop");
+  assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
+  assert(topn.getTopFromKey(10, "k1").length == 1, "getTopFromKey for topn wrong result");
+  assert(topn.getTopFromKey(10, "k1")[0] == "k", "getTopFromKey for topn wrong result");
+  assert(topn.getTopWithRating(10).length == 2, "getTopWithRating for topn with 1 element is wrong size");
+  assert(topn.getTopWithRating(10)[0].value == 6, "getTopWithRating for topn with 1 element is wrong size");
+  assert(topn.getTopWithRating(10)[1].value == 5, "getTopWithRating for topn with 1 element is wrong size");
 
-//   topn.delete("k1");
-//   topn.incrementRating("k");
-//   assert(!topn.isEmpty, "topn - wrong result for isEmpty");
-//   assert(topn.length == 1, "topn - wrong length");
-//   assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
-//   assert(topn.contains("k"), "topn - does not contain a key that should be there");
-//   topn.delete("nonexistentKey"); // this should not crash
-//   assert(topn.keysToRatings(["k"]).length == 1, "keys to ratings wrong for topn");
-//   assert(topn.keysToRatings(["k"])[0].value == 6, "keys to ratings wrong for topn");
-//   assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
-//   assert(topn.getTop(10)[0] == "k", "wrong key in getTop")
-//   assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
-//   assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
-//   assert(topn.getTopWithRatingFromKey(10, "k").length == 0, "getTopWithRatingFromKey for topn is not empty");
-// }
+  topn.delete("k1");
+  topn.incrementRating("k");
+  assert(!topn.isEmpty, "topn - wrong result for isEmpty");
+  assert(topn.length == 1, "topn - wrong length");
+  assert(!topn.contains("nonexistentKey"), "topn - contains nonexistent key");
+  assert(topn.contains("k"), "topn - does not contain a key that should be there");
+  topn.delete("nonexistentKey"); // this should not crash
+  assert(topn.keysToRatings(["k"]).length == 1, "keys to ratings wrong for topn");
+  assert(topn.keysToRatings(["k"])[0].value == 6, "keys to ratings wrong for topn");
+  assert(topn.getTop(10).length == 1, "get top for topn returned non empty list");
+  assert(topn.getTop(10)[0] == "k", "wrong key in getTop")
+  assert(topn.getTopFromKey(10, "k").length == 0, "getTopFromKey for topn wrong result");
+  assert(topn.getTopWithRating(10).length == 1, "getTopWithRating for topn with 1 element is wrong size");
+  assert(topn.getTopWithRatingFromKey(10, "k").length == 0, "getTopWithRatingFromKey for topn is not empty");
+}
 
-// export function contextTests(): void {
-//   logging.log("contextTests");
-//   assert(context.sender == "bob", "Wrong sender");
-//   assert(context.contractName == "contractaccount", "Wrong contract name");
-//   assert(context.blockIndex == 113, "Wrong contract name");
-//   assert(context.attachedDeposit == u128.fromU64(7), "Wrong receivedAmount");
-//   assert(context.accountBalance == u128.fromU64(14), "Wrong receivedAmount");
-//   assert(context.prepaidGas == 1000000000, "Wrong prepaid gas");
-//   assert(context.usedGas <= 1000000000, "Wrong used gas");
-//   assert(context.usedGas > 0, "Wrong used gas");
-//   //assert(context.storageUsage == 0, "Wrong storage usage"); TODO: test when implemented
-// }
+export function contextTests(): void {
+  logging.log("contextTests");
+  assert(context.sender == "bob", "Wrong sender");
+  assert(context.contractName == "contractaccount", "Wrong contract name");
+  assert(context.blockIndex == 113, "Wrong contract name");
+  assert(context.attachedDeposit == u128.fromU64(7), "Wrong receivedAmount");
+  assert(context.accountBalance == u128.fromU64(14), "Wrong receivedAmount");
+  assert(context.prepaidGas == 1000000000, "Wrong prepaid gas");
+  assert(context.usedGas <= 1000000000, "Wrong used gas");
+  assert(context.usedGas > 0, "Wrong used gas");
+  //assert(context.storageUsage == 0, "Wrong storage usage"); TODO: test when implemented
+}
 
-// export function promiseTests(): void {
-//   logging.log("promiseTests");
-//   const emptyResults = ContractPromise.getResults();
-//   assert(emptyResults.length == 0, "wrong length for results");
-//   const promise = ContractPromise.create("contractNameForPromise", "methodName", new Uint8Array(0), 100);
-//   const promise2 = promise.then("contractNameForPromise", "methodName", new Uint8Array(0), 100);
-//   const promise3 = ContractPromise.all([promise2]);
-// }
+export function promiseTests(): void {
+  logging.log("promiseTests");
+  const emptyResults = ContractPromise.getResults();
+  assert(emptyResults.length == 0, "wrong length for results");
+  const promise = ContractPromise.create<Uint8Array>("contractNameForPromise", "methodName", new Uint8Array(0), 100);
+  const promise2 = promise.then<Uint8Array>("contractNameForPromise", "methodName", new Uint8Array(0), 100);
+  const promise3 = ContractPromise.all([promise2]);
+}
 
-// export function mathTests(): void {
-//   logging.log("mathTests");
-//   const array = _testBytes();
-//   const hash = math.hash32Bytes(array);
-//   assert(hash == 3593695342, "wrong hash");
+export function mathTests(): void {
+  logging.log("mathTests");
+  const array = _testBytes();
+  const hash = math.hash32Bytes(array);
+  assert(hash == 3593695342, "wrong hash");
 
-//   const stringValue = "toHash";
-//   const hashOfString = math.hash32(stringValue);
-//   assert(hashOfString == 3394043202, "wrong hash of the string");
+  const stringValue = "toHash";
+  const hashOfString = math.hash32(stringValue);
+  assert(hashOfString == 3394043202, "wrong hash of the string");
 
-//   const hash256 = math.hash(stringValue);
-//   let x: i32[] = [1, 6, 7];
-//   assert(hash256.length == 32, "wrong output length for hash256");
-//   assert(hash256[0] == 202, "wrong contents of hash256");
-//   assert(hash256[1] == 76, "wrong contents of hash256");
-//   assert(hash256[31] == 184, "wrong contents of hash256");
-// }
+  const hash256 = math.hash(stringValue);
+  let x: i32[] = [1, 6, 7];
+  assert(hash256.length == 32, "wrong output length for hash256");
+  assert(hash256[0] == 202, "wrong contents of hash256");
+  assert(hash256[1] == 76, "wrong contents of hash256");
+  assert(hash256[31] == 184, "wrong contents of hash256");
+}
 
 
 // cruft to compare test objects. TODO: use something standard


### PR DESCRIPTION
new API would add generic argument so that users don't have to call encode directly.
