### PR TITLE
Update asc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ install_test_dependencies:
 build_test_wasm:
   stage: build
   script:
-    - cd tests && yarn build
+    - cd tests && yarn && yarn build
 
 build_near_vm_runner_standalone:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ variables:
 
 cache:
   paths:
-    - node_modules/
     - tests/node_modules/
     - tests/nearcore/
     - .cargo/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ cache:
 
 stages:
   - install
+  - install-tests
   - build
   - test
 
@@ -22,7 +23,7 @@ install_dependencies:
     - yarn
 
 install_test_dependencies:
-  stage: install
+  stage: install-tests
   script:
     - cd tests && yarn && yarn remove near-runtime-ts && yarn add ../
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
 
 cache:
   paths:
+    - node_modules/
     - tests/node_modules/
     - tests/nearcore/
     - .cargo/
@@ -20,7 +21,7 @@ stages:
 install_dependencies:
   stage: install
   script:
-    - yarn
+    - yarn --force
 
 install_test_dependencies:
   stage: install-tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,17 +20,17 @@ stages:
 install_dependencies:
   stage: install
   script:
-    - yarn && yarn add nearprotocol/assemblyscript
+    - yarn
 
 install_test_dependencies:
   stage: install
   script:
-    - cd tests && yarn
+    - cd tests && yarn && yarn remove near-runtime-ts && yarn add ../
 
 build_test_wasm:
   stage: build
   script:
-    - cd tests && yarn && yarn build
+    - cd tests && yarn build
 
 build_near_vm_runner_standalone:
   stage: build

--- a/index.js
+++ b/index.js
@@ -1,0 +1,44 @@
+
+
+const DEFAULT_ARGS = [
+  "--baseDir", process.cwd(),
+  "--runtime", "stub"
+]
+let asc;
+function getAsc() {
+  if (asc) {
+    return asc;
+  }
+  try {
+    asc = require("assemblyscript/cli/asc");
+  } catch (e) {
+    asc= require("assemblyscript/dist/asc")
+    
+  }
+  asc.main = (main => (args, options, fn) => {
+    if (typeof options === "function") {
+      fn = options;
+      options = undefined;
+    }
+    return main([...DEFAULT_ARGS, ...args], options, fn);
+  })(asc.main);
+  return asc;
+}
+
+module.exports.asc = getAsc()
+
+module.exports.compile  = function (inputFile, outputFile, args, options, callback){
+  const asc = getAsc()
+  if (typeof args === "function") {
+    option = args;
+    args = [];
+  } else if (typeof options === "function") {
+    callback = options;
+  }
+  asc.main([inputFile,
+  // TODO: Optimiziation is very slow, enable it only conditionally for "prod" builds?
+  "--binaryFile", outputFile,
+  "--textFile",outputFile.substring(0,outputFile.lastIndexOf("."))+ ".wat",
+  ...args
+  ], options || {}, callback);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-runtime-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Near smart contract runtime library for typescript",
   "repository": {
     "type": "git",
@@ -21,13 +21,8 @@
     "bignum": "github:MaxGraey/bignum.wasm"
   },
   "devDependencies": {
-    "@as-pect/cli": "^2.5.0",
-    "ts-loader": "^6.1.2",
-    "ts-node": "^8.4.1",
     "typedoc": "^0.15.0",
-    "typedoc-plugin-markdown": "^1.2.1",
-    "typescript": "^3.6.3",
-    "webpack": "^4.40.2",
-    "webpack-cli": "^3.3.9"
+    "typedoc-plugin-markdown": "^1.2.1"
+
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-runtime-ts",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Near smart contract runtime library for typescript",
   "repository": {
     "type": "git",
@@ -16,13 +16,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "assemblyscript": "github:nearprotocol/assemblyscript#fixFloatingPoint",
     "assemblyscript-json": "0.2.0",
     "bignum": "github:MaxGraey/bignum.wasm"
   },
   "devDependencies": {
     "@as-pect/cli": "^2.5.0",
-    "assemblyscript": "github:nearprotocol/assemblyscript",
+    "ts-loader": "^6.1.2",
+    "ts-node": "^8.4.1",
     "typedoc": "^0.15.0",
-    "typedoc-plugin-markdown": "^1.2.1"
+    "typedoc-plugin-markdown": "^1.2.1",
+    "typescript": "^3.6.3",
+    "webpack": "^4.40.2",
+    "webpack-cli": "^3.3.9"
   }
 }

--- a/tests/as-pect.config.js
+++ b/tests/as-pect.config.js
@@ -124,6 +124,8 @@ module.exports = {
     "--baseDir": __dirname,
     "--notNear":[],
     "--runPasses": ["inlining,dce"],
+    "--transform": ["./node_modules/assemblyscript/bindings/dist/transformerBundle.js"],
+    "--lib": ["./node_modules/assemblyscript/bindings/assembly/nearEntry.js"]
   },
   /**
    * A set of regexp that will disclude source files from testing.

--- a/tests/as-pect.config.js
+++ b/tests/as-pect.config.js
@@ -122,7 +122,8 @@ module.exports = {
     /** To select an appropriate runtime, use the --runtime compiler flag. */
     "--runtime": ["stub"], // Acceptable values are: full, half, stub (arena), and none,
     "--baseDir": __dirname,
-    "--runPasses": ["inlining,dce"]
+    "--notNear":[],
+    "--runPasses": ["inlining,dce"],
   },
   /**
    * A set of regexp that will disclude source files from testing.

--- a/tests/asconfig.js
+++ b/tests/asconfig.js
@@ -1,0 +1,12 @@
+const compile = require("near-runtime-ts").compile;
+
+
+compile("assembly/main.ts", // input file
+        "out/main.wasm",    // output file
+        [
+        //   "-O1",            // Optional arguments
+        "--debug",
+        "--measure"
+        ]);
+
+

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,10 +1,10 @@
 {
   "scripts": {
-    "build:hello": "../node_modules/.bin/asc --runtime stub assembly/hello/main.ts --textFile out/hello/main.wat --validate --debug",
+    "build:hello": "near-asc --runtime stub assembly/hello/main.ts --textFile out/hello/main.wat --validate --debug",
     "pretest": "yarn build:hello && yarn build && ./build-near-vm-runner-standalone.sh",
     "test": "yarn build:hello && yarn asp",
     "asp": "node --experimental-wasm-bigint ../node_modules/.bin/asp",
-    "build": "../node_modules/.bin/asc --runtime stub assembly/main.ts --textFile out/main.wat --binaryFile out/main.wasm --validate --debug"
+    "build": "node asconfig.js"
   },
   "dependencies": {
     "near-runtime-ts": "file:.."

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,10 +3,11 @@
     "build:hello": "near-asc --runtime stub assembly/hello/main.ts --textFile out/hello/main.wat --validate --debug",
     "pretest": "yarn build:hello && yarn build && ./build-near-vm-runner-standalone.sh",
     "test": "yarn build:hello && yarn asp",
-    "asp": "node --experimental-wasm-bigint ../node_modules/.bin/asp",
+    "asp": "node --experimental-wasm-bigint ./node_modules/.bin/asp",
     "build": "node asconfig.js"
   },
   "dependencies": {
+    "@as-pect/cli": "^2.5.0",
     "near-runtime-ts": "file:.."
   }
 }


### PR DESCRIPTION
Currently there are still several issues preventing us from completely diverging from the assemblyscript upstream.  
- Changes to stdlib
- Checks for floats used
- And the bindings code is currently also packaged with the compiler making it easier to use in the browser.

Also the code depends on the source directory of upstream.  I tried with some pain to only depend on the packaged file, but ran into many compiler issues.  The src directory is also not in the list of files that the upstream lists in their package.json.  Luckily yarn ignores this when installing from a github repo.  However, in the future, we'd still like to only depend on the published version of the compiler.  Furthermore, I found it very annoying when there would be different versions of source with varying levels of support, meaning builds would randomly fail.  Again, once we have tagged releases from upstream we can still use yarn to pull it and expect the src directory.

Our major headaches have all stemmed from a lack of versioning so for now I think the best is to just use our fork to version.  I think this could also serve as the version for the binding code.

