### PR TITLE
Tagged runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,32 +19,38 @@ stages:
   - test
 
 install_dependencies:
+  tags: docker
   stage: install
   script:
     - yarn --force
 
 install_test_dependencies:
+  tags: docker
   stage: install-tests
   script:
     - cd tests && yarn && yarn remove near-runtime-ts && yarn add ../
 
 build_test_wasm:
+  tags: docker
   stage: build
   script:
     - cd tests && yarn build
 
 build_near_vm_runner_standalone:
+  tags: docker
   stage: build
   script:
     - export PATH="$PATH:$CARGO_HOME/bin"
     - cd tests && ./build-near-vm-runner-standalone.sh
 
 run_aspect_tests:
+  tags: docker
   stage: test
   script:
     - cd tests && yarn asp
 
 run_assembly_test:
+  tags: docker
   stage: test
   script:
     - cd tests && ./test.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,38 +19,44 @@ stages:
   - test
 
 install_dependencies:
-  tags: docker
+  tags: 
+    - docker
   stage: install
   script:
     - yarn --force
 
 install_test_dependencies:
-  tags: docker
+  tags: 
+    - docker
   stage: install-tests
   script:
     - cd tests && yarn && yarn remove near-runtime-ts && yarn add ../
 
 build_test_wasm:
-  tags: docker
+  tags: 
+    - docker
   stage: build
   script:
     - cd tests && yarn build
 
 build_near_vm_runner_standalone:
-  tags: docker
+  tags: 
+    - docker
   stage: build
   script:
     - export PATH="$PATH:$CARGO_HOME/bin"
     - cd tests && ./build-near-vm-runner-standalone.sh
 
 run_aspect_tests:
-  tags: docker
+  tags: 
+    - docker
   stage: test
   script:
     - cd tests && yarn asp
 
 run_assembly_test:
-  tags: docker
+  tags: 
+    - docker
   stage: test
   script:
     - cd tests && ./test.sh


### PR DESCRIPTION
gitlab runner doesn't treat self hosted runners same way as shared runners. For self hosted runners if job has no tag and you don't have a runner with no tag, no runner will be pickup. 