### PR TITLE
Add bignum to index file

### DIFF
--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -8,3 +8,4 @@ export * from "./base64"
 export * from "./base58";
 export * from "./logging";
 export * from "./math";
+export * from "bignum";


### PR DESCRIPTION
We want to move away from bignum as a dependency, and toward as-bignum.  As a first step this makes other deps should use runtime-ts's version of u128, which can be changed later.